### PR TITLE
feat(Channel page): 채널 페이지 전체 UI 구현

### DIFF
--- a/src/app/(route)/[channel]/components/ChannelProfile.tsx
+++ b/src/app/(route)/[channel]/components/ChannelProfile.tsx
@@ -1,0 +1,24 @@
+
+interface ChannelProfileProps {
+  nickname: string; 
+  follower: number;
+  context: string;
+}
+
+
+const ChannelProfile: React.FC<ChannelProfileProps> = ({nickname, follower, context}) => {  
+  return (
+    <>
+    <div className="flex items-start max-w-7xl p-4 rounded-lg m-2 mt-32">
+        <div className="w-24 h-24 rounded-full bg-white shadow-md text-sm mr-4"/>
+        <div className="flex flex-col mt-2">
+          <p className="text-2xl font-black">{nickname}</p>
+          <p className="text-lg font-semibold text-gray-500">팔로워 {follower}만 명</p>
+          <p className="text-lg font-medium text-gray-400">{context}</p>
+        </div>
+    </div>
+  </>
+  )
+}
+
+export default ChannelProfile

--- a/src/app/(route)/[channel]/components/ChannelProfile.tsx
+++ b/src/app/(route)/[channel]/components/ChannelProfile.tsx
@@ -1,24 +1,26 @@
 
 interface ChannelProfileProps {
-  nickname: string; 
+  nickname: string;
   follower: number;
   context: string;
 }
 
-
-const ChannelProfile: React.FC<ChannelProfileProps> = ({nickname, follower, context}) => {  
+const ChannelProfile: React.FC<ChannelProfileProps> = ({ nickname, follower, context }) => {
   return (
-    <>
-    <div className="flex items-start max-w-7xl p-4 rounded-lg m-2 mt-32">
-        <div className="w-24 h-24 rounded-full bg-white shadow-md text-sm mr-4"/>
-        <div className="flex flex-col mt-2">
+    <div className="flex items-start justify-between max-w-7xl p-4 rounded-lg m-2 mt-32">
+      <div className="flex items-center"> 
+        <div className="w-24 h-24 rounded-full bg-white shadow-md mr-4"/> 
+        <div className="flex-grow flex flex-col justify-center"> 
           <p className="text-2xl font-black">{nickname}</p>
           <p className="text-lg font-semibold text-gray-500">팔로워 {follower}만 명</p>
           <p className="text-lg font-medium text-gray-400">{context}</p>
         </div>
+      </div>
+      <button className="w-20 h-8 bg-[#1bb373] rounded-full flex items-center justify-center text-white font-black">
+        팔로우
+      </button>
     </div>
-  </>
-  )
+  );
 }
 
-export default ChannelProfile
+export default ChannelProfile;

--- a/src/app/(route)/[channel]/components/Post.tsx
+++ b/src/app/(route)/[channel]/components/Post.tsx
@@ -1,0 +1,19 @@
+
+interface PostProps {
+  nickname: string; 
+  content: string; 
+}
+
+const Post: React.FC<PostProps> = ({nickname, content}) => {
+  return (
+    <div className="flex w-full h-48 p-4 bg-gray-50 rounded-lg ">
+          <div className="flex flex-col flex-shrink-0 w-12 h-12 rounded-full bg-white shadow-md text-sm mr-2"/>
+          <div className="flex flex-col flex-wrap">
+            <p className="text-m font-black">{nickname}</p>
+            <div className="text-m w-full h-32 overflow-hidden break-words mt-2">{content}</div>
+          </div>
+        </div>
+  )
+}
+
+export default Post

--- a/src/app/(route)/[channel]/layout.tsx
+++ b/src/app/(route)/[channel]/layout.tsx
@@ -1,0 +1,13 @@
+
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/src/app/(route)/[channel]/page.tsx
+++ b/src/app/(route)/[channel]/page.tsx
@@ -1,0 +1,23 @@
+import ChannelProfile from "./components/ChannelProfile"
+import Post from "./components/Post"
+
+const Channel = () => {
+  return (
+    <>
+      <div className="ml-12 mr-12">
+        <ChannelProfile nickname="엄청난 물고기" follower={2.4} context="매일 물고기 썰 풀어드립니다."/>
+          <p className="text-xl font-black ml-4 mt-6">커뮤니티</p>
+          <div className="flex items-start flex-col max-w-7xl bg-white rounded-lg m-2 mt-6 gap-6">
+            <Post nickname="엄청난 물고기" content="배부른 물고기가 느리다 배부른 물고기가 느리다 배부른 물고기가 느리다 배부른 물고기가 느리다 "/>
+            <Post nickname="엄청난 물고기" content="배부른 물고기가 느리다 배부른 물고기가 느리다 배부른 물고기가 느리다 배부른 물고기가 느리다 "/>
+            <Post nickname="엄청난 물고기" content="배부른 물고기가 느리다 배부른 물고기가 느리다 배부른 물고기가 느리다 배부른 물고기가 느리다 "/>
+
+          </div>
+        <div className="h-32"/>
+      </div>
+    </>
+
+  )
+}
+
+export default Channel


### PR DESCRIPTION
## 🚀 반영 브랜치
`channelPage` → `develop`
`feat/channel/profile` → `channelPage`

<br/>

## ✅ 작업 내용
간단한 채널페이지 전체적인 UI 작업하였습니다.
profile, post 컴포넌트로 분리하였습니다.

<br/>

## 🌠 이미지 첨부

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/6dc60037-0cce-4fcc-9fc5-54336d5f6a85" />
<br/>

## ✏️ 앞으로의 과제

- 글쓰기 페이지, 글 상세 페이지 UI 구현 중 (CRUD와 함께 진행중)
- 커뮤니티 CRUD 
- 페이지 상단 헤더와 왼쪽 사이드바는 공통 컴포넌트로 넣어야 할 것 같습니다.

<br/>

## 📌 이슈 링크

- [ #6 ]
