### PR TITLE
feat(component/footer): footer 공통 컴포넌트 구현

### DIFF
--- a/src/app/_components/Footer/footer.tsx
+++ b/src/app/_components/Footer/footer.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link"
+import { AnchorHTMLAttributes } from "react"
+
+/**
+ * Studio 페이지를 제외한 모든 페이지가 사용하는 footer
+ * 페이지 별 스타일이 달라서 Footer위에 전용 <div>를 감싸서 mt를 조절해 사용하는 것을 권장합니다
+ */
+
+const Footer = () => {
+    const footerList = [
+        {
+            title:"EZZ",
+            url:"#"
+        },
+        {
+            title:"김동균",
+            url:"https://github.com/DonggyunKim00"
+        },
+        {
+            title:"안리안",
+            url:"https://github.com/AhnRian"
+        },{
+            title:"윤가은",
+            url:"https://github.com/yungan9"
+        },{
+            title:"김기준",
+            url:"https://github.com/ki2183"
+        },
+    ];
+
+    return (
+        <footer aria-label="footer" className="flex flex-wrap justify-center m-[0_30px] p-[25px_0_85px] box-border border-solid border-t-[1px] border-[#6666662d]">
+            <div className="flex-none">
+                {footerList.map(({ title, url }, idx) => (
+                    <FooterItem key={idx} url={url}>{title}</FooterItem>
+                ))}
+                <FooterItem key="lastItem" url="https://github.com/9oormthon-2523/chzzk-clone" lastIdx={true}>
+                    <strong>ⓣ 2523.</strong>
+                </FooterItem>
+            </div>
+        </footer>  
+    )
+}
+
+export default Footer;
+
+
+interface FooterItemProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    lastIdx?:boolean
+    url:string
+}
+
+const FooterItem = (props: FooterItemProps) =>{
+    const { url, lastIdx, ...rest} = props;
+    const afterStyle = "after:content-[''] after:absolute after:top-[7px] after:bottom-[7px] after:right-0 after:w-[1px] after:bg-[#6666667d]"
+    return (
+        <Link {...rest} href={url} className={`${!lastIdx ? afterStyle : " "} text-[#666] inline-block text-[12px] leading-[15px] p-[5px_11px_5px_10px] relative align-top hover:underline decoration-gray-500`}/>
+    )
+}


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/footer` → `develop`

<br/>

## ✅ 작업 내용

- StudioPage를 제외한 모든 페이지를 사용하는 공용 footer 제작
- 팀원들의 깃헙 링크와 2523 깃헙 링크를 삽입함
- 페이지 구조가 달라서 MarginTop은 따로 조정을 하지 않았음 <div>로 한번 더 감싸서 마진을 조정하는 것을 권장

<br/>

## 🌠 이미지 첨부
![footer](https://github.com/user-attachments/assets/b457b7d0-b873-4a10-87e2-94a31b909533)
<br/>

## ✏️ 앞으로의 과제

-  로그인 모달 구현
- 스트리밍 미들웨어 학습

<br/>

## 📌 이슈 링크

- [feat/footer #31]
