### PR TITLE
feat(studioPage): 네비게이션 라우트 할당 및 middleware 작업

### DIFF
--- a/src/app/(route)/studio/[uid]/(route)/layout.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/layout.tsx
@@ -19,9 +19,9 @@ const StudioLayout = async ({
   if (match) {
     return (
       <div className="fixed w-full h-full">
-        <Header />
+        <Header uid={uid} />
         <ContentWrapper>
-          <Navigation />
+          <Navigation uid={uid} />
           <section className="flex overflow-auto flex-1 flex-col bg-[#f1f3f5] h-full">
             {children}
           </section>

--- a/src/app/(route)/studio/[uid]/_components/Header/Header.server.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/Header.server.tsx
@@ -5,7 +5,7 @@ import HeaderButton from './HeaderButton.client';
 import ExpandNavButton from './ExpandNavButton.client';
 import ProfileButton from './ProfileButton.client';
 
-const Header = () => {
+const Header = ({ uid }: { uid: string }) => {
   return (
     <header className="bg-[#222] fixed top-0 right-0 flex justify-between items-center px-[20px] py-[10px] w-full z-50">
       <div className="flex items-center gap-2">
@@ -18,8 +18,8 @@ const Header = () => {
             alt="Logo"
           />
         </Link>
-        {/* 쿠키에 저장된 토큰값을 사용하여 API를 호출 후 userIdHash 값을 얻어옴 그 후에 아래의 href에 할당*/}
-        <Link href={`/studio/donggyun`}>
+
+        <Link href={`/studio/${uid}`}>
           <Image
             src={'/studioPage/StudioText.svg'}
             width={79}
@@ -28,8 +28,9 @@ const Header = () => {
           />
         </Link>
       </div>
+
       <div className="flex items-center gap-2">
-        <Link href={'/'} className="h-[40px]">
+        <Link href={`/studio/${uid}/live`} className="h-[40px]">
           <HeaderButton
             imageSrc={'/studioPage/Camera.svg'}
             desc={'방송하기'}
@@ -37,7 +38,7 @@ const Header = () => {
             height={40}
           />
         </Link>
-        <ProfileButton />
+        <ProfileButton uid={uid} />
       </div>
     </header>
   );

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileButton.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileButton.client.tsx
@@ -5,7 +5,7 @@ import HeaderButton from './HeaderButton.client';
 import ProfileMenuList from './ProfileMenu.server';
 import OutsideClickDetector from '@/app/_components/OutsideClickWrapper.client';
 
-const ProfileButton = () => {
+const ProfileButton = ({ uid }: { uid: string }) => {
   const [isOpenMenu, setIsOpenMenu] = useState<boolean>(false);
 
   return (
@@ -21,7 +21,7 @@ const ProfileButton = () => {
 
       {isOpenMenu && (
         <OutsideClickDetector action={() => setIsOpenMenu(false)}>
-          <ProfileMenuList />
+          <ProfileMenuList uid={uid} />
         </OutsideClickDetector>
       )}
     </div>

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
@@ -5,7 +5,7 @@ import MiniChzzk from '@public/studioPage/MiniChzzk.svg';
 import MyChannel from '@public/studioPage/MyChannel.svg';
 import Logout from '@public/studioPage/Logout.svg';
 
-const ProfileMenuList = () => {
+const ProfileMenuList = ({ uid }: { uid: string }) => {
   return (
     <div className="absolute flex flex-col font-blackHanSans w-[240px] bg-white shadow-base rounded-[5px] border border-solid border-[#dddddd] -translate-x-[198px] font-thin">
       <div className="flex flex-col items-center px-[17px] py-[19px] gap-[11px]">
@@ -21,8 +21,7 @@ const ProfileMenuList = () => {
         </strong>
       </div>
       <div className="flex flex-col border border-solid border-[#ebedf3] text-[13px] px-[6px] py-[7px]">
-        {/* 유저의 고유 uuid를 동적 라우트로 넣어야함 */}
-        <Link href={'/channel'}>
+        <Link href={`/channel/${uid}`}>
           <MenuButtonBox icon={<MyChannel />} text="내 채널" color="gray" />
         </Link>
         <Link href={'/'}>

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
@@ -23,12 +23,21 @@ const ProfileMenuList = () => {
       <div className="flex flex-col border border-solid border-[#ebedf3] text-[13px] px-[6px] py-[7px]">
         {/* 유저의 고유 uuid를 동적 라우트로 넣어야함 */}
         <Link href={'/channel'}>
-          <MenuButtonBox icon={<MyChannel />} text="내 채널" />
+          <MenuButtonBox icon={<MyChannel />} text="내 채널" color="gray" />
         </Link>
         <Link href={'/'}>
-          <MenuButtonBox icon={<MiniChzzk />} text="치지직 돌아가기" />
+          <MenuButtonBox
+            icon={<MiniChzzk />}
+            text="치지직 돌아가기"
+            color="gray"
+          />
         </Link>
-        <MenuButtonBox icon={<Logout />} text="로그아웃" onClick={() => {}} />
+        <MenuButtonBox
+          icon={<Logout />}
+          text="로그아웃"
+          color="gray"
+          onClick={() => {}}
+        />
       </div>
     </div>
   );

--- a/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
@@ -13,10 +13,11 @@ interface Props {
   menuName: string;
   icon: ReactNode;
   menuRoute?: string;
+  uid: string;
 }
 
 const NavMenu = (props: Props) => {
-  const { menuName, icon, menuRoute } = props;
+  const { menuName, icon, menuRoute, uid } = props;
 
   const router = useRouter();
 
@@ -34,13 +35,13 @@ const NavMenu = (props: Props) => {
           icon={icon}
           text={menuName}
           menuRoute={menuRoute}
-          color="black"
+          color="gray"
           px={15}
           py={10}
           gap={10}
           onClick={() => {
             if (menuRoute) {
-              router.push(`/${menuRoute}`);
+              router.push(`${menuRoute}`);
             } else {
               if (isFold) toggle();
               setIsOpen((prev) => !prev);
@@ -59,7 +60,7 @@ const NavMenu = (props: Props) => {
       </li>
 
       {/* 서브 메뉴들이 존재하면서 열려있을때 서브메뉴 렌더링 */}
-      {!menuRoute && isOpen && <SubMenus menuName={menuName} />}
+      {!menuRoute && isOpen && <SubMenus menuName={menuName} uid={uid} />}
 
       {/* 네비게이션이 접혔을때, hover시 description 띄우기 */}
       {isFold && (

--- a/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
@@ -8,6 +8,8 @@ import useNavSizeToggle from '@/app/_store/studio/useNavSizeToggle.client';
 import '@/app/_styles/studioPage.css';
 import SubMenus from './SubMenus';
 import { useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
+import { getMenuList } from '@/app/_utils/studio/getMenuList';
 
 interface Props {
   menuName: string;
@@ -22,11 +24,14 @@ const NavMenu = (props: Props) => {
   const router = useRouter();
 
   const { isFold, toggle } = useNavSizeToggle();
-  const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   useEffect(() => {
     if (isFold) setIsOpen(false);
   }, [isFold]);
+
+  const pathname = usePathname();
+  const menuListRouteArr = getMenuList(uid)[menuName].map((item) => item.route);
 
   return (
     <div className="flex flex-col relative group">
@@ -35,7 +40,9 @@ const NavMenu = (props: Props) => {
           icon={icon}
           text={menuName}
           menuRoute={menuRoute}
-          color="gray"
+          color={
+            menuListRouteArr.includes(pathname) && !isOpen ? 'blue' : 'black'
+          }
           px={15}
           py={10}
           gap={10}

--- a/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
@@ -4,47 +4,24 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import MenuButtonBox from '../common/MenuButtonBox.client';
 import ArrowDownIcon from '@public/studioPage/ArrowDown.svg';
 import ArrowUpIcon from '@public/studioPage/ArrowUp.svg';
-import NavDeptIcon from '@public/studioPage/NavDept.svg';
-import { useRouter } from 'next/navigation';
 import useNavSizeToggle from '@/app/_store/studio/useNavSizeToggle.client';
 import '@/app/_styles/studioPage.css';
-
-interface MenuType {
-  text: string;
-  route: string;
-}
-
-const uid = '1d8940af-d8ce-43e6-9d59-549f988160ab';
-
-const menus: Record<string, MenuType[]> = {
-  대시보드: [],
-  '방송 관리': [
-    { text: '방송하기', route: `studio/${uid}/live` },
-    { text: '설정', route: `studio/${uid}/settings` },
-    { text: '알림', route: `studio/${uid}/notice` },
-    { text: '리허설 방송 하기', route: `studio/${uid}/rehearsal` },
-  ],
-  '시청자 관리': [
-    { text: '팔로워', route: `studio/${uid}/follower` },
-    { text: '구독자', route: `studio/${uid}/subscriber` },
-    { text: '활동 제한', route: `studio/${uid}/blocklist` },
-  ],
-};
+import SubMenus from './SubMenus';
+import { useRouter } from 'next/navigation';
 
 interface Props {
-  text: string;
-  hideMenu: boolean;
+  menuName: string;
   icon: ReactNode;
-  menuRoute: string;
+  menuRoute?: string;
 }
 
 const NavMenu = (props: Props) => {
-  const { text, hideMenu, icon, menuRoute } = props;
+  const { menuName, icon, menuRoute } = props;
+
+  const router = useRouter();
 
   const { isFold, toggle } = useNavSizeToggle();
-
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const router = useRouter();
 
   useEffect(() => {
     if (isFold) setIsOpen(false);
@@ -55,18 +32,22 @@ const NavMenu = (props: Props) => {
       <li className="flex items-center py-[1px] px-[10px] box-border font-blackHanSans text-[15px]">
         <MenuButtonBox
           icon={icon}
-          text={text}
+          text={menuName}
           menuRoute={menuRoute}
           px={15}
           py={10}
           gap={10}
           onClick={() => {
-            if (isFold) toggle();
-            setIsOpen((prev) => !prev);
+            if (menuRoute) {
+              router.push(`/${menuRoute}`);
+            } else {
+              if (isFold) toggle();
+              setIsOpen((prev) => !prev);
+            }
           }}
         />
 
-        {!isFold && hideMenu && (
+        {!isFold && !menuRoute && (
           <button
             className="absolute right-[25px]"
             onClick={() => setIsOpen((prev) => !prev)}
@@ -76,33 +57,13 @@ const NavMenu = (props: Props) => {
         )}
       </li>
 
-      {hideMenu && isOpen && (
-        <div className="font-blackHanSans">
-          {menus[text].map((item) => (
-            <MenuButtonBox
-              key={item.text}
-              icon={
-                <div className="relative -top-[2px]">
-                  <NavDeptIcon />
-                </div>
-              }
-              text={item.text}
-              menuRoute={item.route}
-              px={48}
-              py={13}
-              gap={6}
-              fontSize={14}
-              onClick={() => {
-                router.push(`/${item.route}`);
-              }}
-            />
-          ))}
-        </div>
-      )}
+      {/* 서브 메뉴들이 존재하면서 열려있을때 서브메뉴 렌더링 */}
+      {!menuRoute && isOpen && <SubMenus menuName={menuName} />}
 
+      {/* 네비게이션이 접혔을때, hover시 description 띄우기 */}
       {isFold && (
         <span className="absolute transform top-1/2 -translate-y-1/2 right-1/4 translate-x-full group-button-desc rounded-md hover-opacity">
-          {text}
+          {menuName}
         </span>
       )}
     </div>

--- a/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/NavMenu.client.tsx
@@ -34,6 +34,7 @@ const NavMenu = (props: Props) => {
           icon={icon}
           text={menuName}
           menuRoute={menuRoute}
+          color="black"
           px={15}
           py={10}
           gap={10}

--- a/src/app/(route)/studio/[uid]/_components/Navigation/Navigation.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/Navigation.client.tsx
@@ -7,9 +7,7 @@ import StudioIcon from '@public/studioPage/Studio.svg';
 import ViewerIcon from '@public/studioPage/Viewer.svg';
 import useNavSizeToggle from '@/app/_store/studio/useNavSizeToggle.client';
 
-const uid = '1d8940af-d8ce-43e6-9d59-549f988160ab';
-
-const Navigation = () => {
+const Navigation = ({ uid }: { uid: string }) => {
   const { isFold } = useNavSizeToggle();
 
   return (
@@ -26,9 +24,10 @@ const Navigation = () => {
           menuName="대시보드"
           icon={<DashboardIcon />}
           menuRoute={`/studio/${uid}`}
+          uid={uid}
         />
-        <NavMenu menuName="방송 관리" icon={<StudioIcon />} />
-        <NavMenu menuName="시청자 관리" icon={<ViewerIcon />} />
+        <NavMenu menuName="방송 관리" icon={<StudioIcon />} uid={uid} />
+        <NavMenu menuName="시청자 관리" icon={<ViewerIcon />} uid={uid} />
       </ul>
     </nav>
   );

--- a/src/app/(route)/studio/[uid]/_components/Navigation/Navigation.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/Navigation.client.tsx
@@ -5,7 +5,6 @@ import NavMenu from './NavMenu.client';
 import DashboardIcon from '@public/studioPage/Dashboard.svg';
 import StudioIcon from '@public/studioPage/Studio.svg';
 import ViewerIcon from '@public/studioPage/Viewer.svg';
-import Link from 'next/link';
 import useNavSizeToggle from '@/app/_store/studio/useNavSizeToggle.client';
 
 const uid = '1d8940af-d8ce-43e6-9d59-549f988160ab';
@@ -23,26 +22,13 @@ const Navigation = () => {
       }}
     >
       <ul>
-        <Link href={`/studio/${uid}`}>
-          <NavMenu
-            text="대시보드"
-            hideMenu={false}
-            icon={<DashboardIcon />}
-            menuRoute={`/studio/${uid}`}
-          />
-        </Link>
         <NavMenu
-          text="방송 관리"
-          hideMenu={true}
-          icon={<StudioIcon />}
-          menuRoute="/studio/1"
+          menuName="대시보드"
+          icon={<DashboardIcon />}
+          menuRoute={`/studio/${uid}`}
         />
-        <NavMenu
-          text="시청자 관리"
-          hideMenu={true}
-          icon={<ViewerIcon />}
-          menuRoute="/studio/2"
-        />
+        <NavMenu menuName="방송 관리" icon={<StudioIcon />} />
+        <NavMenu menuName="시청자 관리" icon={<ViewerIcon />} />
       </ul>
     </nav>
   );

--- a/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
@@ -11,28 +11,31 @@ interface MenuType {
   isImplement: boolean;
 }
 
-const uid = '1d8940af-d8ce-43e6-9d59-549f988160ab';
-const menuList: Record<string, MenuType[]> = {
-  대시보드: [],
-  '방송 관리': [
-    { text: '방송하기', route: `studio/${uid}/live`, isImplement: true },
-    { text: '설정', route: `studio/${uid}/settings`, isImplement: false },
-    { text: '알림', route: `studio/${uid}/notice`, isImplement: false },
-    {
-      text: '리허설 방송 하기',
-      route: `studio/${uid}/rehearsal`,
-      isImplement: false,
-    },
-  ],
-  '시청자 관리': [
-    { text: '팔로워', route: `studio/${uid}/follower`, isImplement: true },
-    { text: '구독자', route: `studio/${uid}/subscriber`, isImplement: false },
-    { text: '활동 제한', route: `studio/${uid}/blocklist`, isImplement: false },
-  ],
-};
-
-const SubMenu = ({ menuName }: { menuName: string }) => {
+const SubMenu = ({ menuName, uid }: { menuName: string; uid: string }) => {
   const router = useRouter();
+
+  const menuList: Record<string, MenuType[]> = {
+    대시보드: [],
+    '방송 관리': [
+      { text: '방송하기', route: `studio/${uid}/live`, isImplement: true },
+      { text: '설정', route: `studio/${uid}/settings`, isImplement: false },
+      { text: '알림', route: `studio/${uid}/notice`, isImplement: false },
+      {
+        text: '리허설 방송 하기',
+        route: `studio/${uid}/rehearsal`,
+        isImplement: false,
+      },
+    ],
+    '시청자 관리': [
+      { text: '팔로워', route: `studio/${uid}/follower`, isImplement: true },
+      { text: '구독자', route: `studio/${uid}/subscriber`, isImplement: false },
+      {
+        text: '활동 제한',
+        route: `studio/${uid}/blocklist`,
+        isImplement: false,
+      },
+    ],
+  };
 
   return (
     <div className="font-blackHanSans">

--- a/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
@@ -4,38 +4,11 @@ import React from 'react';
 import MenuButtonBox from '../common/MenuButtonBox.client';
 import NavDeptIcon from '@public/studioPage/NavDept.svg';
 import { useRouter } from 'next/navigation';
-
-interface MenuType {
-  text: string;
-  route: string;
-  isImplement: boolean;
-}
+import { getMenuList } from '@/app/_utils/studio/getMenuList';
 
 const SubMenu = ({ menuName, uid }: { menuName: string; uid: string }) => {
   const router = useRouter();
-
-  const menuList: Record<string, MenuType[]> = {
-    대시보드: [],
-    '방송 관리': [
-      { text: '방송하기', route: `studio/${uid}/live`, isImplement: true },
-      { text: '설정', route: `studio/${uid}/settings`, isImplement: false },
-      { text: '알림', route: `studio/${uid}/notice`, isImplement: false },
-      {
-        text: '리허설 방송 하기',
-        route: `studio/${uid}/rehearsal`,
-        isImplement: false,
-      },
-    ],
-    '시청자 관리': [
-      { text: '팔로워', route: `studio/${uid}/follower`, isImplement: true },
-      { text: '구독자', route: `studio/${uid}/subscriber`, isImplement: false },
-      {
-        text: '활동 제한',
-        route: `studio/${uid}/blocklist`,
-        isImplement: false,
-      },
-    ],
-  };
+  const menuList = getMenuList(uid);
 
   return (
     <div className="font-blackHanSans">
@@ -55,7 +28,7 @@ const SubMenu = ({ menuName, uid }: { menuName: string; uid: string }) => {
           gap={6}
           fontSize={14}
           onClick={() => {
-            if (item.isImplement) router.push(`/${item.route}`);
+            if (item.isImplement) router.push(item.route);
             else alert('추후에 구현 예정입니다.');
           }}
         />

--- a/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
@@ -46,6 +46,7 @@ const SubMenu = ({ menuName }: { menuName: string }) => {
           }
           text={item.text}
           menuRoute={item.route}
+          color="gray"
           px={48}
           py={13}
           gap={6}

--- a/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Navigation/SubMenus.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React from 'react';
+import MenuButtonBox from '../common/MenuButtonBox.client';
+import NavDeptIcon from '@public/studioPage/NavDept.svg';
+import { useRouter } from 'next/navigation';
+
+interface MenuType {
+  text: string;
+  route: string;
+  isImplement: boolean;
+}
+
+const uid = '1d8940af-d8ce-43e6-9d59-549f988160ab';
+const menuList: Record<string, MenuType[]> = {
+  대시보드: [],
+  '방송 관리': [
+    { text: '방송하기', route: `studio/${uid}/live`, isImplement: true },
+    { text: '설정', route: `studio/${uid}/settings`, isImplement: false },
+    { text: '알림', route: `studio/${uid}/notice`, isImplement: false },
+    {
+      text: '리허설 방송 하기',
+      route: `studio/${uid}/rehearsal`,
+      isImplement: false,
+    },
+  ],
+  '시청자 관리': [
+    { text: '팔로워', route: `studio/${uid}/follower`, isImplement: true },
+    { text: '구독자', route: `studio/${uid}/subscriber`, isImplement: false },
+    { text: '활동 제한', route: `studio/${uid}/blocklist`, isImplement: false },
+  ],
+};
+
+const SubMenu = ({ menuName }: { menuName: string }) => {
+  const router = useRouter();
+
+  return (
+    <div className="font-blackHanSans">
+      {menuList[menuName].map((item) => (
+        <MenuButtonBox
+          key={item.text}
+          icon={
+            <div className="relative -top-[2px]">
+              <NavDeptIcon />
+            </div>
+          }
+          text={item.text}
+          menuRoute={item.route}
+          px={48}
+          py={13}
+          gap={6}
+          fontSize={14}
+          onClick={() => {
+            if (item.isImplement) router.push(`/${item.route}`);
+            else alert('추후에 구현 예정입니다.');
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SubMenu;

--- a/src/app/(route)/studio/[uid]/_components/common/MenuButtonBox.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/common/MenuButtonBox.client.tsx
@@ -13,7 +13,7 @@ interface Props {
   px?: number;
   py?: number;
   fontSize?: number;
-  color: 'black' | 'gray';
+  color: 'black' | 'gray' | 'blue';
 }
 
 const MenuButtonBox = (props: Props) => {
@@ -32,6 +32,7 @@ const MenuButtonBox = (props: Props) => {
   const fontColor = {
     black: 'text-[#222222]',
     gray: 'text-[#525662]',
+    blue: 'text-[#4e41db]',
   };
 
   return (
@@ -39,7 +40,6 @@ const MenuButtonBox = (props: Props) => {
       className={`w-full flex p-[10px] hover:bg-[#f5f6f8] rounded-[5px] items-center ${fontColor[color]}`}
       style={{
         padding: `${py}px ${px}px`,
-        color: `${isMatchDomain && '#4e41db'}`,
         fontSize: `${fontSize}px`,
       }}
       onClick={onClick}
@@ -51,6 +51,7 @@ const MenuButtonBox = (props: Props) => {
           opacity: isFold ? '0' : '1',
           marginLeft: isFold ? '0px' : `${gap}px`,
           width: isFold ? '0px' : `137px`,
+          color: isMatchDomain ? '#4e41db' : 'inherit',
         }}
       >
         {text}

--- a/src/app/(route)/studio/[uid]/_components/common/MenuButtonBox.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/common/MenuButtonBox.client.tsx
@@ -24,6 +24,7 @@ const MenuButtonBox = (props: Props) => {
 
   useEffect(() => {
     if (menuRoute && menuRoute === pathname) setIsMatchDomain(true);
+    else setIsMatchDomain(false);
   }, [menuRoute, pathname]);
 
   return (

--- a/src/app/(route)/studio/[uid]/_components/common/MenuButtonBox.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/common/MenuButtonBox.client.tsx
@@ -13,10 +13,12 @@ interface Props {
   px?: number;
   py?: number;
   fontSize?: number;
+  color: 'black' | 'gray';
 }
 
 const MenuButtonBox = (props: Props) => {
-  const { icon, text, onClick, menuRoute, px, py, gap, fontSize } = props;
+  const { icon, text, onClick, menuRoute, px, py, gap, fontSize, color } =
+    props;
 
   const { isFold } = useNavSizeToggle();
   const [isMatchDomain, setIsMatchDomain] = useState(false);
@@ -27,14 +29,17 @@ const MenuButtonBox = (props: Props) => {
     else setIsMatchDomain(false);
   }, [menuRoute, pathname]);
 
+  const fontColor = {
+    black: 'text-[#222222]',
+    gray: 'text-[#525662]',
+  };
+
   return (
     <button
-      className={`w-full flex p-[10px] hover:bg-[#f5f6f8] rounded-[5px] items-center`}
+      className={`w-full flex p-[10px] hover:bg-[#f5f6f8] rounded-[5px] items-center ${fontColor[color]}`}
       style={{
         padding: `${py}px ${px}px`,
-        color: `${
-          isMatchDomain ? '#4e41db' : menuRoute ? '#222222' : '#525662'
-        }`,
+        color: `${isMatchDomain && '#4e41db'}`,
         fontSize: `${fontSize}px`,
       }}
       onClick={onClick}

--- a/src/app/_utils/studio/getMenuList.ts
+++ b/src/app/_utils/studio/getMenuList.ts
@@ -1,0 +1,32 @@
+interface MenuType {
+  text: string;
+  route: string;
+  isImplement: boolean;
+}
+
+export const getMenuList = (uid: string): Record<string, MenuType[]> => ({
+  대시보드: [],
+  '방송 관리': [
+    { text: '방송하기', route: `/studio/${uid}/live`, isImplement: true },
+    { text: '설정', route: `/studio/${uid}/settings`, isImplement: false },
+    { text: '알림', route: `/studio/${uid}/notice`, isImplement: false },
+    {
+      text: '리허설 방송 하기',
+      route: `/studio/${uid}/rehearsal`,
+      isImplement: false,
+    },
+  ],
+  '시청자 관리': [
+    { text: '팔로워', route: `/studio/${uid}/follower`, isImplement: true },
+    {
+      text: '구독자',
+      route: `/studio/${uid}/subscriber`,
+      isImplement: false,
+    },
+    {
+      text: '활동 제한',
+      route: `/studio/${uid}/blocklist`,
+      isImplement: false,
+    },
+  ],
+});

--- a/src/app/_utils/supabase/middleware.ts
+++ b/src/app/_utils/supabase/middleware.ts
@@ -1,0 +1,36 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  // refreshing the auth token
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+import { type NextRequest } from 'next/server';
+import { updateSession } from '@/app/_utils/supabase/middleware';
+
+export async function middleware(request: NextRequest) {
+  // update user's auth session
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * Feel free to modify this pattern to include more paths.
+     */
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## 🚀 반영 브랜치
`studioPage` → `develop`

<br/>

## ✅ 작업 내용
- 스튜디오 페이지 네비게이션 라우트에 따른 색상 처리
- 스튜디오 페이지 라우트 동적 할당
- 로그인 토큰 업데이트 하는 middlware.ts 구현

<br/>

## ✏️ 앞으로의 과제

- `/studio` 라우팅시 쿠키값에 따른 `/studio/[uid]` 로 리다이렉팅
- `/studio/[uid]/live` 페이지 스트리밍 테스트
- supabase Auth에 유저 등록시 유저 프로필을 담는 DB 스키마에 자동 insert 되는 Route Handler 구현

<br/>

## 📌 이슈 링크

- #43
- #45 
- #46  