### PR TITLE
feat(studioPage): 로그인 유저 토큰을 이용한 헤더 프로필 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'k.kakaocdn.net',
+      },
+    ],
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,

--- a/src/app/(route)/studio/[uid]/_components/Header/Header.server.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/Header.server.tsx
@@ -4,8 +4,13 @@ import React from 'react';
 import HeaderButton from './HeaderButton.client';
 import ExpandNavButton from './ExpandNavButton.client';
 import ProfileButton from './ProfileButton.client';
+import { headers } from 'next/headers';
+import { use } from 'react';
+import { User } from '@supabase/supabase-js';
 
 const Header = ({ uid }: { uid: string }) => {
+  const { user } = use(getUserProfile());
+
   return (
     <header className="bg-[#222] fixed top-0 right-0 flex justify-between items-center px-[20px] py-[10px] w-full z-50">
       <div className="flex items-center gap-2">
@@ -38,10 +43,21 @@ const Header = ({ uid }: { uid: string }) => {
             height={40}
           />
         </Link>
-        <ProfileButton uid={uid} />
+        <ProfileButton uid={uid} user={user} />
       </div>
     </header>
   );
 };
 
 export default Header;
+
+const getUserProfile = async (): Promise<{ user: User }> => {
+  const header = await headers();
+  const response = await fetch('http://localhost:3000/api/auth/user', {
+    headers: {
+      cookie: header.get('cookie') || '',
+    },
+  });
+
+  return response.json();
+};

--- a/src/app/(route)/studio/[uid]/_components/Header/HeaderButton.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/HeaderButton.client.tsx
@@ -28,7 +28,13 @@ const HeaderButton = ({
       }}
       onClick={onClick}
     >
-      <Image src={imageSrc} width={width} height={height} alt={desc} />
+      <Image
+        src={imageSrc}
+        width={width}
+        height={height}
+        alt={desc}
+        className="rounded-full aspect-square"
+      />
       <span
         className="absolute-center group-button-desc transition-button hover-opacity"
         style={{

--- a/src/app/(route)/studio/[uid]/_components/Header/HeaderButton.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/HeaderButton.client.tsx
@@ -4,6 +4,7 @@ import '@/app/_styles/studioPage.css';
 import Image from 'next/image';
 
 interface ButtonProps {
+  id?: string;
   imageSrc: string;
   desc: string;
   width: number;
@@ -13,6 +14,7 @@ interface ButtonProps {
 }
 
 const HeaderButton = ({
+  id,
   imageSrc,
   desc,
   width,
@@ -22,6 +24,7 @@ const HeaderButton = ({
 }: ButtonProps) => {
   return (
     <button
+      id={id}
       className="transition-button relative group hover:bg-neutral-700"
       style={{
         padding: `${padding}px`,

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileButton.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileButton.client.tsx
@@ -4,14 +4,21 @@ import React, { useState } from 'react';
 import HeaderButton from './HeaderButton.client';
 import ProfileMenuList from './ProfileMenu.server';
 import OutsideClickDetector from '@/app/_components/OutsideClickWrapper.client';
+import { User } from '@supabase/supabase-js';
 
-const ProfileButton = ({ uid }: { uid: string }) => {
+export interface ProfileProps {
+  uid: string;
+  user: User;
+}
+
+const ProfileButton = (props: ProfileProps) => {
+  const { uid, user } = props;
   const [isOpenMenu, setIsOpenMenu] = useState<boolean>(false);
 
   return (
     <div className="relative">
       <HeaderButton
-        imageSrc={'/studioPage/Profile.svg'}
+        imageSrc={user.user_metadata.avatar_url}
         desc={'내 프로필'}
         width={30}
         height={30}
@@ -21,7 +28,7 @@ const ProfileButton = ({ uid }: { uid: string }) => {
 
       {isOpenMenu && (
         <OutsideClickDetector action={() => setIsOpenMenu(false)}>
-          <ProfileMenuList uid={uid} />
+          <ProfileMenuList uid={uid} user={user} />
         </OutsideClickDetector>
       )}
     </div>

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileButton.client.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileButton.client.tsx
@@ -18,6 +18,7 @@ const ProfileButton = (props: ProfileProps) => {
   return (
     <div className="relative">
       <HeaderButton
+        id="ignored-header"
         imageSrc={user.user_metadata.avatar_url}
         desc={'내 프로필'}
         width={30}
@@ -27,7 +28,10 @@ const ProfileButton = (props: ProfileProps) => {
       />
 
       {isOpenMenu && (
-        <OutsideClickDetector action={() => setIsOpenMenu(false)}>
+        <OutsideClickDetector
+          ignoreIds={['ignored-header']}
+          action={() => setIsOpenMenu(false)}
+        >
           <ProfileMenuList uid={uid} user={user} />
         </OutsideClickDetector>
       )}

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
@@ -5,9 +5,12 @@ import MiniChzzk from '@public/studioPage/MiniChzzk.svg';
 import MyChannel from '@public/studioPage/MyChannel.svg';
 import Logout from '@public/studioPage/Logout.svg';
 import { ProfileProps } from './ProfileButton.client';
+import { createClient } from '@/app/_utils/supabase/client';
+import { useRouter } from 'next/navigation';
 
 const ProfileMenuList = (props: ProfileProps) => {
   const { uid, user } = props;
+  const router = useRouter();
 
   return (
     <div className="absolute flex flex-col font-blackHanSans w-[240px] bg-white shadow-base rounded-[5px] border border-solid border-[#dddddd] -translate-x-[198px] font-thin">
@@ -38,7 +41,11 @@ const ProfileMenuList = (props: ProfileProps) => {
           icon={<Logout />}
           text="로그아웃"
           color="gray"
-          onClick={() => {}}
+          onClick={async () => {
+            const supabase = createClient();
+            const { error } = await supabase.auth.signOut();
+            if (!error) router.push('/studio');
+          }}
         />
       </div>
     </div>

--- a/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
+++ b/src/app/(route)/studio/[uid]/_components/Header/ProfileMenu.server.tsx
@@ -4,20 +4,23 @@ import Link from 'next/link';
 import MiniChzzk from '@public/studioPage/MiniChzzk.svg';
 import MyChannel from '@public/studioPage/MyChannel.svg';
 import Logout from '@public/studioPage/Logout.svg';
+import { ProfileProps } from './ProfileButton.client';
 
-const ProfileMenuList = ({ uid }: { uid: string }) => {
+const ProfileMenuList = (props: ProfileProps) => {
+  const { uid, user } = props;
+
   return (
     <div className="absolute flex flex-col font-blackHanSans w-[240px] bg-white shadow-base rounded-[5px] border border-solid border-[#dddddd] -translate-x-[198px] font-thin">
       <div className="flex flex-col items-center px-[17px] py-[19px] gap-[11px]">
         <Image
-          src={'/studioPage/Profile.svg'}
+          src={user.user_metadata.avatar_url}
           width={62}
           height={62}
           alt="profile"
-          className="border border-solid border-[#dddddd] box-border rounded-full"
+          className="border border-solid border-[#dddddd] box-border rounded-full aspect-square"
         />
         <strong className="text-[#222] text-[16px] leading-[17px]">
-          밤새는 겜돌이
+          {user.user_metadata.full_name}
         </strong>
       </div>
       <div className="flex flex-col border border-solid border-[#ebedf3] text-[13px] px-[6px] py-[7px]">

--- a/src/app/_components/OutsideClickWrapper.client.tsx
+++ b/src/app/_components/OutsideClickWrapper.client.tsx
@@ -5,20 +5,31 @@ import React, { useEffect, useRef } from 'react';
 interface Props {
   action: () => void; // 바깥이 클릭되었을 때 실행할 로직
   children: React.ReactNode;
+  ignoreIds?: string[];
 }
 
-const OutsideClickWrapper = ({ action, children }: Props) => {
+const OutsideClickWrapper = ({ action, children, ignoreIds }: Props) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   // 바깥 클릭 감지
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(event.target as Node))
+      const target = event.target as HTMLElement;
+
+      // 제외할 ID에 해당하는 요소인지 확인
+      const isIgnored =
+        ignoreIds && ignoreIds.some((id) => target.closest(`#${id}`));
+
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node) &&
+        !isIgnored
+      )
         action();
     };
 
     document.addEventListener('mousedown', handleClickOutside);
-  }, [action]);
+  }, [action, ignoreIds]);
 
   return <div ref={modalRef}>{children}</div>;
 };


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/studio/profile` → `studioPage`

<br/>

## ✅ 작업 내용

- `uid`, `user` 타입을 정의한 ProfileProps interface 타입 추가
- 유저 쿠키값에 포함된 `user_metadata` 를 이용하여 프로필 사진, 프로필 이름 적용
- 로그아웃 API 연동, 로그아웃 성공시 라우트 이동 처리

<br/>

## 🌠 이미지 첨부

<img width="339" alt="스크린샷 2025-01-01 오후 5 39 45" src="https://github.com/user-attachments/assets/09a62b44-2121-4ab4-85a8-ec157ab661b2" />


<br/>

## ✏️ 앞으로의 과제

- 유저 토큰값의 필요 유무에 따른 supabase 테이블 사용 논의

<br/>

## 📌 이슈 링크

- #51 
