### PR TITLE
featI/studioPage/live/streaming): 호스트 스트리밍 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.3",
+    "agora-rtc-sdk-ng": "^4.23.0",
     "axios": "^1.7.9",
     "next": "15.1.0",
     "react": "^19.0.0",

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingBtn.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingBtn.client.tsx
@@ -1,18 +1,11 @@
-'use client';
+"use clinet"
 
-import React from 'react';
+import dynamic from 'next/dynamic';
+const StreamingCoreBtn = dynamic(() => import('./StreamingCoreBtn.client'), { ssr: false });
 
 const StreamingBtn = () => {
-  return (
-    <button
-      className="rounded-2xl bg-white text-[#697183] text-[15px] font-blackHanSans py-[5px] px-[15px]"
-      onClick={() => {
-        // 여기에 로직 추가하면 될듯합니다!
-      }}
-    >
-      스트리밍 시작하기
-    </button>
-  );
-};
-
-export default StreamingBtn;
+    return <>
+      <StreamingCoreBtn/>
+    </>
+}
+export default StreamingBtn

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingBtn.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingBtn.client.tsx
@@ -1,11 +1,31 @@
-"use clinet"
+"use client";
 
+import { createClient } from '@/app/_utils/supabase/client';
+import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+
 const StreamingCoreBtn = dynamic(() => import('./StreamingCoreBtn.client'), { ssr: false });
 
 const StreamingBtn = () => {
-    return <>
-      <StreamingCoreBtn/>
-    </>
-}
-export default StreamingBtn
+  const supabase = createClient();
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data: user, error } = await supabase.auth.getUser();
+      if (!error && user) {
+        setUserId(user.user.id);
+      }
+      setLoading(false);
+    };
+    fetchUser();
+  }, []);
+
+  if (loading) return null;
+  
+
+  return <>{userId ? <StreamingCoreBtn uid={userId} /> : <p>사용자 정보를 불러올 수 없습니다.</p>}</>;
+};
+
+export default StreamingBtn;

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
@@ -1,17 +1,72 @@
 'use client';
+import useStudioManager from '@/app/_hooks/studio/useStudioManager';
+import { useState } from 'react';
 
-import React from 'react';
+interface StreamingCoreBtnProps {
+  uid:string
+}
 
-const StreamingCoreBtn = () => {
+const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
+  const { uid } = props;
+  const [loading, setLoading] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const { streamOn, streamOff, addTrackShare, stopTrackShare} = useStudioManager(uid);
+
+  const handleStreamToggle = async () => {
+      setLoading(true);
+
+      if (isStreaming) {
+          // 스트리밍 종료
+          const success = await streamOff();
+          if (success) setIsStreaming(false);
+      } else {
+          // 스트리밍 시작
+          const success = await streamOn();
+          if (success) setIsStreaming(true);
+      }
+
+      setLoading(false);
+  };
+
+  //스크린 정지 후 마이크 연결
+  const screenSTOP = async() => {
+    setLoading(true);
+    await stopTrackShare();
+    await addTrackShare("mic");
+    setLoading(false);
+  }
+
+  //공유 선택
+  const screenChange = async() => {
+    setLoading(true);
+    await addTrackShare();
+    setLoading(false);
+  }
+
   return (
+    <>
     <button
       className="rounded-2xl bg-white text-[#697183] text-[15px] font-blackHanSans py-[5px] px-[15px]"
-      onClick={() => {
-        // 여기에 로직 추가하면 될듯합니다!
-      }}
+      onClick={handleStreamToggle}
     >
-      스트리밍 시작하기
+      {loading ? "처리 중..." : isStreaming ? "스트리밍 종료" : "스트리밍 시작하기"}
     </button>
+
+    { (!loading && isStreaming) && <button
+      className="rounded-2xl bg-white text-[#697183] text-[15px] font-blackHanSans py-[5px] px-[15px]"
+      onClick={screenSTOP}
+    >
+      화면 공유 정지
+    </button>}
+
+    
+    { (!loading && isStreaming) && <button
+      className="rounded-2xl bg-white text-[#697183] text-[15px] font-blackHanSans py-[5px] px-[15px]"
+      onClick={screenChange}
+    >
+      화면 공유 변경
+    </button>}
+    </>
   );
 };
 

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
@@ -11,7 +11,7 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
   const [loading, setLoading] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const { streamOn, streamOff, addTrackShare, stopTrackShare, volumeControl } = useStudioManager(uid);
-  const { audioState, controlAudio, muteAudio, viewAudio } = volumeControl();
+  const { audioState, controlAudio, viewAudio } = volumeControl();
   
 
   const handleStreamToggle = async () => {
@@ -30,10 +30,15 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
       setLoading(false);
   };
 
-  //스크린 정지 후 마이크 연결
+  //스크린 정지
   const screenSTOP = async() => {
     setLoading(true);
     await stopTrackShare();
+    setLoading(false);
+  }
+
+  const micOn = async() => {
+    setLoading(true);
     await addTrackShare("mic");
     setLoading(false);
   }
@@ -41,6 +46,7 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
   //공유 선택
   const screenChange = async() => {
     setLoading(true);
+    // await stopTrackShare();
     await addTrackShare();
     setLoading(false);
   }  
@@ -59,6 +65,13 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
       onClick={screenSTOP}
     >
       화면 공유 정지
+    </button>}
+
+    { (!loading && isStreaming) && <button
+      className="rounded-2xl bg-white text-[#697183] text-[15px] font-blackHanSans py-[5px] px-[15px]"
+      onClick={micOn}
+    >
+      마이크만키기
     </button>}
 
     

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+
+const StreamingCoreBtn = () => {
+  return (
+    <button
+      className="rounded-2xl bg-white text-[#697183] text-[15px] font-blackHanSans py-[5px] px-[15px]"
+      onClick={() => {
+        // 여기에 로직 추가하면 될듯합니다!
+      }}
+    >
+      스트리밍 시작하기
+    </button>
+  );
+};
+
+export default StreamingCoreBtn;

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingCoreBtn.client.tsx
@@ -1,6 +1,6 @@
 'use client';
-import useStudioManager from '@/app/_hooks/studio/useStudioManager';
-import { useState } from 'react';
+import useStudioManager from '@/app/_hooks/studio/useStudioManager.client';
+import React, { useState } from 'react';
 
 interface StreamingCoreBtnProps {
   uid:string
@@ -10,7 +10,9 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
   const { uid } = props;
   const [loading, setLoading] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
-  const { streamOn, streamOff, addTrackShare, stopTrackShare} = useStudioManager(uid);
+  const { streamOn, streamOff, addTrackShare, stopTrackShare, volumeControl } = useStudioManager(uid);
+  const { audioState, controlAudio, muteAudio, viewAudio } = volumeControl();
+  
 
   const handleStreamToggle = async () => {
       setLoading(true);
@@ -41,7 +43,7 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
     setLoading(true);
     await addTrackShare();
     setLoading(false);
-  }
+  }  
 
   return (
     <>
@@ -66,6 +68,33 @@ const StreamingCoreBtn = (props: StreamingCoreBtnProps) => {
     >
       화면 공유 변경
     </button>}
+
+  
+    {
+      audioState('mic').isActive && (
+        <input
+          type="range"
+          step={1}
+          min={0}
+          max={1000}
+          value={viewAudio.mic}
+          onChange={(e) => controlAudio('mic', Number(e.currentTarget.value))}
+        />
+      )
+    }
+
+  {
+      audioState('screen').isActive && (
+        <input
+          type="range"
+          step={1}
+          min={0}
+          max={1000}
+          value={viewAudio.screen}
+          onChange={(e) => controlAudio('screen', Number(e.currentTarget.value))}
+        />
+      )
+    }
     </>
   );
 };

--- a/src/app/(route)/studio/[uid]/(route)/live/page.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import StreamingBtn from './_components/StreamingBtn.client';
 
 const StudioLivePage = () => {
+
   return (
     <div className="flex w-full h-full">
       {/* 스트리밍 세팅 영역 */}

--- a/src/app/_hooks/studio/useStudioManager.client.ts
+++ b/src/app/_hooks/studio/useStudioManager.client.ts
@@ -1,0 +1,229 @@
+import type * as AgoraRTCType from "agora-rtc-sdk-ng";
+import AgoraRTC from "agora-rtc-sdk-ng";
+import { useRef } from "react";
+
+
+/**
+ * 호스트가 사용하는 스트리밍 훅
+ */
+
+
+interface ScreenTrackPayload {
+    frameRate?:number, 
+    bitrateMax?: number, 
+    bitrateMin?: number, 
+}
+
+type cleanUpTrackType = React.MutableRefObject<AgoraRTCType.ILocalVideoTrack | AgoraRTCType.ILocalAudioTrack | AgoraRTCType.ILocalVideoTrack | null>
+
+//함수 밖에서 사용할 때 필요한 인자 헷갈려서 나중에 사용 예정
+type exceptionResorce = "screen" | "mic" ;
+type mediaResource = "all" | exceptionResorce;
+
+const useStudioManager = (uid: string) => {
+    const channel_ = "demo"
+    const APP_ID = process.env.NEXT_PUBLIC_AGORA_APP_ID! || "";
+    const clientRef = useRef<AgoraRTCType.IAgoraRTCClient | null>(null);
+    const screenTrackRef = useRef<null | AgoraRTCType.ILocalVideoTrack>(null);
+    const screenAudioRef = useRef<null | AgoraRTCType.ILocalAudioTrack>(null);
+    const micTrackRef = useRef<null | AgoraRTCType.IMicrophoneAudioTrack>(null);
+
+    /** 미디어 **/
+    //#region 
+
+    // 트랙 초기화
+    const cleanUpTrack = (trackRef: cleanUpTrackType) => {
+        if (!trackRef.current) return;
+        const track = trackRef.current;
+        track.stop();
+        track.close();
+        trackRef.current = null;
+        console.log(`${track} 리소스 초기화 완료`);
+    };
+        
+    // 미디어 공유 해제
+    const unpublishMediaTracks = async () => {
+        const tracks = [micTrackRef, screenAudioRef, screenTrackRef];
+    
+        try {
+            if (!clientRef.current) return;
+            if (!(await clientConnectState())) return;
+        
+            // 트랙 언퍼블리시 및 정리
+            for (const trackRef of tracks) {
+                if (trackRef.current) {
+                await clientRef.current.unpublish(trackRef.current);
+                cleanUpTrack(trackRef);
+                }
+            }
+        
+            console.log("모든 미디어 트랙 언퍼블리시 및 초기화 완료");
+
+        } catch (err: unknown) {
+            console.error("언퍼블리싱 실패. 모든 리소스를 초기화합니다.");
+    
+            // 실패 시 리소스 정리
+            for (const trackRef of tracks) {
+                if (trackRef.current) cleanUpTrack(trackRef);
+            }
+    
+            console.error(err);
+        }
+    };
+
+    // 미디어 추출 및 퍼블리시
+    const extractMediaTrack = async ( type: mediaResource = 'all', payload?: ScreenTrackPayload) => {
+        const { frameRate = 60, bitrateMax = 2500, bitrateMin = 1500 } = payload || {};
+        const encoderConfig = { frameRate, bitrateMax, bitrateMin };
+
+        try {
+            if (type === "mic" || type === "all") {
+                try {
+                  const micTrack = await AgoraRTC.createMicrophoneAudioTrack();
+                  clientRef.current?.publish(micTrack);
+                  micTrackRef.current = micTrack;
+                  console.log("마이크 트랙 생성 및 퍼블리시 성공");
+                } catch (error) {
+                  console.warn("마이크 트랙 생성 실패: 마이크 없이 진행합니다.", error);
+                }
+            }
+      
+          // 화면 공유 트랙 생성 및 퍼블리시
+            if (type === "screen" || type === "all") {
+                try {
+                const [screenTrack, screenAudioTrack] = await AgoraRTC.createScreenVideoTrack(
+                    { encoderConfig },
+                    "enable"
+                );
+                if (screenTrack && screenAudioTrack) {
+                    await clientRef.current?.publish([screenTrack, screenAudioTrack]);
+                    screenTrackRef.current = screenTrack;
+                    screenAudioRef.current = screenAudioTrack;
+                    console.log("화면 공유 트랙 퍼블리시 성공");
+                }
+                } catch (error) {
+                    console.error("화면 공유 트랙 생성 실패", error);
+                    throw new Error("화면 공유 트랙 생성 실패: 진행 중단");
+                }
+             }
+        } catch (err: unknown) {
+            console.error("미디어 퍼블리싱 실패:", err);
+            await unpublishMediaTracks(); // 이미 퍼블리시된 트랙 정리
+            throw new Error("미디어 퍼블리싱 실패");
+        }
+      };
+
+    //#endregion
+
+
+    /** 클라이언트 **/
+    //#region 
+
+    // 클라이언트 생성 및 채널 참가
+    const initializeClient = async () => {
+        if (!clientRef.current) {
+            const client = AgoraRTC.createClient({ mode: "rtc", codec: "vp8", role: "host" });
+            clientRef.current = client;
+            await client.join(APP_ID, channel_, null, uid);
+            console.log("클라이언트 초기화 및 채널 참가 완료");
+        }
+    };
+
+    // 채널 연결 상태일 때만 true
+    const clientConnectState = async () => {
+        if (!clientRef.current) return false;
+        if (clientRef.current.connectionState !== "CONNECTED") return false;
+        return true;
+    }
+
+    // 클라이언트 해제
+    const delClient = async () => {
+        try {
+            if (clientRef.current) {
+                await clientRef.current.leave();
+                console.log("채널 종료 완료.");
+
+                clientRef.current = null;
+                console.log("클라이언트 해제 완료.");
+                return;
+            } else {
+                console.log("클라이언트가 이미 해제된 상태입니다.");
+            }
+        } catch (err: unknown) {
+            alert('클라이언트를 해제하는 중 오류가 발생했습니다. 새로 고침으로 강제 종료해주세요.')
+            throw new Error("클라이언트를 해제하는 중 오류가 발생했습니다.");
+        }
+    };
+
+    //#endregion
+
+
+    /** 스트리밍 **/
+    //#region 
+
+    //스트리밍 시작
+    const streamOn = async () => {
+        try {
+            //클라이언트 생성
+            await initializeClient();
+
+            //트랙 생성
+            await extractMediaTrack();            
+            return true;
+        } catch (err: unknown) {
+            console.log("클라이언트 생성 실패",err);
+            await delClient();
+            await unpublishMediaTracks();
+            return false;
+        } 
+    }
+
+    //스트리밍 종료
+    const streamOff = async () => {
+        try {     
+            await unpublishMediaTracks();
+            await delClient();
+            return true;
+        } catch (err: unknown) {
+            console.log(err);
+            return false;
+        } 
+    }
+
+    //스트리밍 중 트랙 리소스 해제
+    const stopTrackShare = async () => {
+        try {
+            await unpublishMediaTracks();    
+        } catch (err: unknown) {
+            alert('실패! 버튼을 한 번 더 눌러주세요');
+            console.log("미디어 트랙 초기화 실패");
+        }
+    }
+
+    //미디어 트랙 추가 및 변경(변경하고 싶은 트랙 선택)
+    const addTrackShare = async (type: mediaResource = "all") => {
+        try {
+            await unpublishMediaTracks();
+            await extractMediaTrack(type);
+
+        } catch (err: unknown) {
+            console.error("트랙 추가 중 오류 발생:", err);
+            alert("오류로 인해 모든 미디어 공유가 중단되었습니다.");
+            
+            // 오류 발생 시 모든 트랙 제거
+            await unpublishMediaTracks();
+            return false;
+        }
+    };
+
+    //#endregion
+
+    return {
+        streamOn,
+        streamOff,
+        addTrackShare,
+        stopTrackShare,    
+    }
+}
+
+export default useStudioManager;


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/studioPage/live/streaming` → `studioPage`

<br/>

## ✅ 작업 내용

- install agora-rtc-sdk-ng
-기존에 develope 브랜치에서 푸시된 스트리밍 훅은 클라이언트와 미디어 리소스가 분리되어 확장성이 제한적이었음. 이를 개선
- 볼륨 조절은 테스트 버튼(range)을 구현해서 기능 연결함
- 주요 기능
     - streamOn : 호스트 클라이언트 생성 -> 채널 참가 -> 미디어 리소스 생성 -> publish
     - streamOff : 미디어 리소스 unpublish -> 미디어 리소스 off 및 제거 -> 채널 나가기 -> 클라이언트 삭제
     - addTrackShare : 스크린 + 마이크 트랙 공유, 스크린 공유 , 마이크 공유
     - stopTrackShare : 모든 미디어 리소스 off 및 해제
     - volumeControl: 볼륨 컨트롤 훅

<br/>

## 🌠 이미지 첨부
방송 키기전
![image](https://github.com/user-attachments/assets/b8abb822-74e1-406c-971c-d43ac7d3829c)

방송 시작 버튼을 눌렀을 때 표시한 오디오 공유도 켜줘야 작동
![image](https://github.com/user-attachments/assets/5eb1ee70-2df7-4317-a8d9-c8f0f96e5071)

화면 공유 + 마이크 공유 상태
![image](https://github.com/user-attachments/assets/00bec21b-5b57-4758-8799-1bc47824d308)

마이크만 공유 상태
![image](https://github.com/user-attachments/assets/787b8be4-7344-48af-9bdc-29b9535dc5b9)

공유 잘됨
<img width="832" alt="image" src="https://github.com/user-attachments/assets/a3a93dc5-2fab-4aa6-a67a-8878c14b0803" />

<br/>

## ✏️ 앞으로의 과제

- Live Page에서 일부 데이터를 SSR(Server Side Rendering) 방식으로 처리하도록 변경
- streaming_room 테이블의 데이터를 제공하는 API 작성

<br/>

## 📌 이슈 링크

- [feat/studioPage/live/streaming#54(이슈 주소)
