### PR TITLE
feat(ChannelPage): 채널 수정 페이지 (settings)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
     });
     return config;
   },
+  images: {
+    domains: ['img1.kakaocdn.net'],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(route)/channel/[uid]/settings/layout.tsx
+++ b/src/app/(route)/channel/[uid]/settings/layout.tsx
@@ -1,0 +1,13 @@
+
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+    </div>
+  )
+}

--- a/src/app/(route)/channel/[uid]/settings/page.tsx
+++ b/src/app/(route)/channel/[uid]/settings/page.tsx
@@ -1,18 +1,49 @@
 'use client';
+
 import React, { useState, useEffect } from 'react';
 import { createClient } from '@/app/_utils/supabase/client';
 
-const Settings = () => {
-  const [user, setUser] = useState<null | { email: string; id: string; name: string }>(null);
+interface UserType {
+  email: string;
+  id: string;
+  name: string;
+  img: string;
+}
+
+export default function Settings() {
   const supabase = createClient();
+
+  const [user, setUser] = useState<UserType | null>(null);
+  const [newImage, setNewImage] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string>('');
 
   const fetchUser = async () => {
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("사용자 정보가 존재하지 않습니다.");
-      setUser({ email: user.email ?? '', id: user.id, name: user.user_metadata.full_name });
+      const {
+        data: { user: supabaseUser },
+        error: getUserError,
+      } = await supabase.auth.getUser();
+
+      if (getUserError) {
+        throw new Error(getUserError.message);
+      }
+
+      if (!supabaseUser) {
+        throw new Error('사용자 정보가 존재하지 않습니다.');
+      }
+
+      setUser({
+        email: supabaseUser.email ?? '',
+        id: supabaseUser.id,
+        name: supabaseUser.user_metadata?.full_name ?? '',
+        img: supabaseUser.user_metadata?.avatar_url ?? '',
+      });
+
+      if (supabaseUser.user_metadata?.avatar_url) {
+        setPreviewUrl(supabaseUser.user_metadata.avatar_url);
+      }
     } catch (error) {
-      console.error("사용자 정보 불러오기 오류", error);
+      console.error('사용자 정보 불러오기 오류', error);
     }
   };
 
@@ -20,48 +51,128 @@ const Settings = () => {
     fetchUser();
   }, []);
 
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      const file = event.target.files[0];
+      setNewImage(file);
+
+      const objectUrl = URL.createObjectURL(file);
+      setPreviewUrl(objectUrl);
+    }
+  };
+
   const updateUser = async () => {
-    if (!user) return; 
+    if (!user) return;
+
     try {
-      const { data, error } = await supabase.auth.updateUser({
+      let finalImageUrl = user.img;
+
+      if (newImage) {
+        const filePath = `avatars/${user.id}/${Date.now()}_${newImage.name}`;
+
+        const { error: uploadError } = await supabase.storage
+          .from('avatars')
+          .upload(filePath, newImage);
+
+        if (uploadError) {
+          throw new Error(`이미지 업로드 오류: ${uploadError.message}`);
+        }
+
+        const { data: publicUrlData } = supabase.storage.from('avatars').getPublicUrl(filePath);
+
+        if (!publicUrlData) {
+          throw new Error('이미지 URL 가져오기 오류');
+        }
+
+        if (publicUrlData?.publicUrl) {
+          finalImageUrl = publicUrlData.publicUrl;
+        }
+      }
+
+      const { data: updatedUser, error: updateError } = await supabase.auth.updateUser({
         data: {
-          full_name: user.name, 
+          full_name: user.name,
+          avatar_url: finalImageUrl,
         },
       });
 
-      if (error) {
-        console.error('사용자 업데이트 실패:', error.message);
-      } else {
-        console.log('사용자 업데이트 성공:', data);
+      if (updateError) {
+        throw new Error(`사용자 업데이트 실패: ${updateError.message}`);
       }
+
+      setUser((prevUser) => {
+        if (!prevUser) return null;
+        return {
+          ...prevUser,
+          name: user.name, 
+          img: finalImageUrl,
+        };
+      });
+
+      setNewImage(null); 
+      console.log('사용자 업데이트 성공', updatedUser);
+      alert('프로필이 업데이트되었습니다!');
     } catch (error) {
-      console.error('사용자 정보 업데이트 중 오류 발생', error);
+      console.error('프로필 업데이트 오류', error);
     }
   };
 
   return (
-    <div className='mx-12'>
+    <div className="mx-12">
       <div className="h-32" />
-      <button className='inline-flex justify-center mr-2 py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-gray-200 text-gray-500 '>취소</button>
-      <button 
-        className='inline-flex justify-center py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-[#1bb373] text-white '
-        onClick={updateUser}>저장</button>
-      <div className='h-96 bg-gray-100 rounded-xl'>
+      <button
+        className="inline-flex justify-center mr-2 py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-gray-200 text-gray-500"
+        onClick={() => {
+          window.history.back();
+        }}
+      >
+        취소
+      </button>
+      <button
+        className="inline-flex justify-center py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-[#1bb373] text-white"
+        onClick={updateUser}
+      >
+        저장
+      </button>
+
+      <div className="h-96 bg-gray-100 rounded-xl mt-4 p-4">
         {user ? (
-          <div className='flex flex-col'>
-            <p>이메일</p>
-            <div>{user.email}</div>
-            <textarea
-              value={user.name}
-              onChange={(e) => setUser({ ...user, name: e.target.value })}
-            />
+          <div className="flex flex-col gap-4">
+            <div>
+              <p className="font-bold text-gray-700">이메일</p>
+              <div>{user.email}</div>
+            </div>
+
+            <div>
+              <p className="font-bold text-gray-700">이름</p>
+              <input
+                className="border rounded p-1 w-64"
+                value={user.name}
+                onChange={(e) => setUser({ ...user, name: e.target.value })}
+              />
+            </div>
+
+            <div className="flex flex-col items-center">
+              <p className="font-bold text-gray-700">프로필 사진</p>
+              {previewUrl ? (
+                <img
+                  src={previewUrl}
+                  alt="새 프로필 미리 보기"
+                  width={100}
+                  height={100}
+                  className="rounded-full object-cover mb-2"
+                />
+              ) : (
+                <div className="w-[100px] h-[100px] bg-gray-300 rounded-full mb-2" />
+              )}
+
+              <input type="file" onChange={handleImageChange} />
+            </div>
           </div>
         ) : (
-          <div className='text-center'>사용자 정보를 불러오는 중...</div>
+          <div className="text-center">사용자 정보를 불러오는 중...</div>
         )}
       </div>
     </div>
   );
 }
-
-export default Settings;

--- a/src/app/(route)/channel/[uid]/settings/page.tsx
+++ b/src/app/(route)/channel/[uid]/settings/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+import React, { useState, useEffect } from 'react';
+import { createClient } from '@/app/_utils/supabase/client';
+
+const Settings = () => {
+  const [user, setUser] = useState<null | { email: string; id: string; name: string }>(null);
+  const supabase = createClient();
+
+  const fetchUser = async () => {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error("사용자 정보가 존재하지 않습니다.");
+      setUser({ email: user.email ?? '', id: user.id, name: user.user_metadata.full_name });
+    } catch (error) {
+      console.error("사용자 정보 불러오기 오류", error);
+    }
+  };
+
+  useEffect(() => {
+    fetchUser();
+  }, []);
+
+  const updateUser = async () => {
+    if (!user) return; 
+    try {
+      const { data, error } = await supabase.auth.updateUser({
+        data: {
+          full_name: user.name, 
+        },
+      });
+
+      if (error) {
+        console.error('사용자 업데이트 실패:', error.message);
+      } else {
+        console.log('사용자 업데이트 성공:', data);
+      }
+    } catch (error) {
+      console.error('사용자 정보 업데이트 중 오류 발생', error);
+    }
+  };
+
+  return (
+    <div className='mx-12'>
+      <div className="h-32" />
+      <button className='inline-flex justify-center mr-2 py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-gray-200 text-gray-500 '>취소</button>
+      <button 
+        className='inline-flex justify-center py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-[#1bb373] text-white '
+        onClick={updateUser}>저장</button>
+      <div className='h-96 bg-gray-100 rounded-xl'>
+        {user ? (
+          <div className='flex flex-col'>
+            <p>이메일</p>
+            <div>{user.email}</div>
+            <textarea
+              value={user.name}
+              onChange={(e) => setUser({ ...user, name: e.target.value })}
+            />
+          </div>
+        ) : (
+          <div className='text-center'>사용자 정보를 불러오는 중...</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Settings;

--- a/src/app/(route)/channel/[uid]/settings/page.tsx
+++ b/src/app/(route)/channel/[uid]/settings/page.tsx
@@ -16,6 +16,10 @@ export default function Settings() {
   const [user, setUser] = useState<UserType | null>(null);
   const [newImage, setNewImage] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string>('');
+  const [nickname, setNickname] = useState<string>(user?.name || '');
+  const [channelIntro, setChannelIntro] = useState<string>('');
+  const [nicknameLength, setNicknameLength] = useState<number>(nickname.length);
+  const [channelIntroLength, setChannelIntroLength] = useState<number>(channelIntro.length);
 
   const fetchUser = async () => {
     try {
@@ -91,7 +95,7 @@ export default function Settings() {
 
       const { data: updatedUser, error: updateError } = await supabase.auth.updateUser({
         data: {
-          full_name: user.name,
+          full_name: nickname,
           avatar_url: finalImageUrl,
         },
       });
@@ -104,7 +108,7 @@ export default function Settings() {
         if (!prevUser) return null;
         return {
           ...prevUser,
-          name: user.name, 
+          name: nickname,
           img: finalImageUrl,
         };
       });
@@ -117,56 +121,84 @@ export default function Settings() {
     }
   };
 
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    setNicknameLength(e.target.value.length);
+  };
+
+  const handleChannelIntroChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setChannelIntro(e.target.value);
+    setChannelIntroLength(e.target.value.length);
+  };
+
   return (
     <div className="mx-12">
       <div className="h-32" />
-      <button
-        className="inline-flex justify-center mr-2 py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-gray-200 text-gray-500"
-        onClick={() => {
-          window.history.back();
-        }}
-      >
-        취소
-      </button>
-      <button
-        className="inline-flex justify-center py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-[#1bb373] text-white"
-        onClick={updateUser}
-      >
-        저장
-      </button>
-
-      <div className="h-96 bg-gray-100 rounded-xl mt-4 p-4">
+      <div className="flex items-center justify-end">
+        <button
+          className="inline-flex justify-center mr-2 py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-gray-200 text-gray-500"
+          onClick={() => {
+            window.history.back();
+          }}
+        >
+          취소
+        </button>
+        <button
+          className="inline-flex justify-center py-2 px-4 w-16 border border-transparent shadow-sm text-sm rounded-md mt-4 font-black bg-[#1bb373] text-white"
+          onClick={updateUser}
+        >
+          저장
+        </button>
+      </div>
+      <div className="bg-gray-50 rounded-xl mt-4 p-6">
         {user ? (
           <div className="flex flex-col gap-4">
-            <div>
-              <p className="font-bold text-gray-700">이메일</p>
-              <div>{user.email}</div>
+            <div className="flex gap-2">
+              <p className="w-24 mt-4 shrink-0 font-bold text-gray-700 mr-6 mb-24">프로필 이미지</p>
+              <div className="flex flex-row items-center gap-2">
+                {previewUrl ? (
+                  <div className="rounded-full w-[140px] h-[140px] overflow-hidden">
+                    <img
+                      src={previewUrl}
+                      alt="새 프로필 미리 보기"
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                ) : (
+                  <div className="w-[100px] h-[100px] bg-gray-300 rounded-full mb-2" />
+                )}
+                <label className="ml-2 inline-flex items-center h-9 px-4 py-2 bg-gray-50 text-sm font-semibold rounded-md cursor-pointer border border-gray-200 hover:bg-gray-200">
+                  이미지 수정
+                  <input type="file" onChange={handleImageChange} className="hidden" />
+                </label>
+              </div>
             </div>
 
-            <div>
-              <p className="font-bold text-gray-700">이름</p>
+            <div className="flex flex-row gap-2 mt-4">
+              <p className="w-24 mr-8 shrink-0 font-bold text-gray-700">이메일</p>
+              <div className='text-sm'>{user.email}</div>
+            </div>
+
+            <div className="flex flex-row gap-2 mt-4">
+              <p className="w-24 mr-8 shrink-0 font-bold text-gray-700">닉네임</p>
               <input
-                className="border rounded p-1 w-64"
-                value={user.name}
-                onChange={(e) => setUser({ ...user, name: e.target.value })}
+                className="w-full border rounded p-2 w-64 text-sm bg-gray-100 focus:border-[#8dd9b9] focus:bg-white focus:outline-none"
+                value={nickname}
+                onChange={handleNicknameChange}
+                maxLength={10}
               />
+              <div className="w-16 text-sm text-gray-500">{nicknameLength} / 10</div> 
             </div>
 
-            <div className="flex flex-col items-center">
-              <p className="font-bold text-gray-700">프로필 사진</p>
-              {previewUrl ? (
-                <img
-                  src={previewUrl}
-                  alt="새 프로필 미리 보기"
-                  width={100}
-                  height={100}
-                  className="rounded-full object-cover mb-2"
-                />
-              ) : (
-                <div className="w-[100px] h-[100px] bg-gray-300 rounded-full mb-2" />
-              )}
-
-              <input type="file" onChange={handleImageChange} />
+            <div className="flex flex-row gap-2 mt-4">
+              <p className="w-24 mr-8 shrink-0 font-bold text-gray-700">채널 소개</p>
+              <textarea
+                className="w-full h-20 border rounded outline-none resize-none p-2 w-64 text-sm bg-gray-100 focus:border-[#8dd9b9] focus:bg-white"
+                value={channelIntro}
+                onChange={handleChannelIntroChange}
+                maxLength={100}
+              />
+              <div className="w-16 text-sm text-gray-500">{channelIntroLength} / 100</div>
             </div>
           </div>
         ) : (


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/channelPage` → `develop`

`feat/channel/channel` → `feat/channelPage`

<br/>

## ✅ 작업 내용

- 수정 페이지 전체적인 UI
- 카카오 로그인한 유저 정보 불러오기 (이름, 이메일, 프로필 사진)
- 유저 정보 수정 (이름, 프로필 사진, 채널 소개)
- 유저 정보 수정시 auth.users, public.users 같이 업데이트

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/40540ccd-152d-4dcb-b152-069160f9fef5)
<br/>

## ✏️ 앞으로의 과제

- 채널 수정 페이지 라우팅

<br/>

## 📌 이슈 링크

- #74 
- #75 
