### PR TITLE
feat(livePage-chat): 스트리밍 룸에 들어온 이후의 채팅만 렌더링되는 방식으로 기능 변경

### DIFF
--- a/src/app/(route)/live/[id]/widget/Chat.client.tsx
+++ b/src/app/(route)/live/[id]/widget/Chat.client.tsx
@@ -1,9 +1,11 @@
 "use client";
+
 import useScreenControl from "@/app/_store/live/useScreenControl";
 import ChatWindow from "../components/Chat/ChatWindow.client";
 import ChatHeader from "../components/Chat/Header.client";
 import ChatInput from "../components/Chat/Input.client";
 import { useChat } from "@/app/_hooks/useChat";
+
 import { CSSProperties, useState } from "react";
 /**
  * 채팅 컨테이너 컴포넌트
@@ -16,15 +18,17 @@ const ChatLayout = ({ roomId }: { roomId: string }) => {
 
   if (!isChatOpen) return null;
 
-  const viewChat_style:CSSProperties = {
+  const viewChat_style: CSSProperties = {
     width: chatPosition === "side" ? "353px" : "auto",
     flex: chatPosition === "side" ? undefined : "1",
   };
+
   const handleSendMessage = async () => {
     if (!newMessage.trim()) return;
     await sendMessage(newMessage);
     setNewMessage("");
   };
+
   return (
     <aside
       id="view-chat"

--- a/src/app/_types/chat/Chat.ts
+++ b/src/app/_types/chat/Chat.ts
@@ -1,6 +1,6 @@
 export type Message = {
-  id: number;
-  user_id: number;
+  id: string;
+  room_id: string;
   nickname: string;
   message: string;
   created_at: string;


### PR DESCRIPTION

## 🚀 반영 브랜치
`livePage-chat` → `livePage`

<br/>

## ✅ 작업 내용

- roomId로 채널 구독하고 그 채널에 존재하는 사용자에게만 brodcast로 입력된 채팅을 전송하는 방식으로 수정하였습니다.
- 스트리밍 룸에 들어온 이후의 채팅만 보이게 됩니다.

<br/>

## 🌠 이미지 첨부

[사용자 1]
![KakaoTalk_Photo_2025-01-07-16-45-40](https://github.com/user-attachments/assets/6bb0794f-5c61-4bff-9ca6-bf779cfa9a08)

[사용자 2]
<img width="356" alt="KakaoTalk_Photo_2025-01-07-16-45-53" src="https://github.com/user-attachments/assets/fbc45b51-d1a4-434d-8c9b-e6da1b29f7ac" />



<br/>

## ✏️ 앞으로의 과제

- 사용자 닉네임 클릭시 그 사용자의 채널 페이지 이동
- 메인페이지 streming_rooms 테이블 데이터로 라이브중인 방송 렌더링

<br/>

## 📌 이슈 링크

#70 
