### PR TITLE
feat(studioPage/live/audienceCnt): 시청자 카운팅 기능 구현

### DIFF
--- a/src/app/_hooks/studio/audience/useAudienceCnt.tsx
+++ b/src/app/_hooks/studio/audience/useAudienceCnt.tsx
@@ -1,0 +1,124 @@
+import { createClient } from "@/app/_utils/supabase/client";
+import { RealtimeChannel } from "@supabase/supabase-js";
+import { useEffect, useState, useRef } from "react";
+
+/**
+ * 시청자 수 파악
+ */
+
+interface useAudienceCntPayload {
+    host_uid: string;
+}
+
+const useAudienceCnt = (payload: useAudienceCntPayload) => {
+    const { host_uid } = payload;
+    
+    const supabase = createClient();
+    const intervalRef = useRef<NodeJS.Timeout | null>(null); // 타이머 ID 저장
+    const [audience, setAudience] = useState<Record<string, number>>({});  // 시청자 dto 저장
+    const [pingChannel, setPingChannel] = useState<RealtimeChannel | null>(null); // 채널 저장
+
+    const TIME = 10 * 1000;
+
+    // db 업데이트
+    const updateAudienceCnt = async (cnt: number) => {
+        const { error } = await supabase
+            .from('streaming_rooms')
+            .update({ audience_cnt: cnt })
+            .eq('uid', host_uid); 
+    
+        if (error) {
+            console.log("시청자 수 반영 실패", error.message);
+        } else {
+            console.log("시청자 수 반영 성공");
+        }
+    };
+
+    // 채널 활성화
+    const activateChannel = () => {
+        if (pingChannel) return; 
+
+        const channel = supabase.channel(`audienceCnt:${host_uid}`);
+        setPingChannel(channel);
+
+        // 채널 구독 생성 및 확인
+        channel.subscribe((status) => {
+            if (status === "SUBSCRIBED") {
+                console.log(`Successfully subscribed to audienceCnt:${host_uid}`);
+            }
+        });
+
+
+        // 'ping' TIME초마다 시청자들에게 메시지 전송
+        intervalRef.current = setInterval(() => {
+            channel.send({
+                type: "broadcast",
+                event: "ping",
+                payload: { host_uid },
+            });
+            
+            setAudience((prev) => {
+                const now = Date.now();
+                // 갱신이 안된 시청자 제외
+                const activeAudiences = Object.entries(prev).filter(([_, timestamp]) => now - timestamp < TIME);
+                const updated = Object.fromEntries(activeAudiences);
+
+                // 필터링된 시청자 db에 갱신함
+                updateAudienceCnt(activeAudiences.length);
+
+                return updated;
+            });
+        }, TIME);
+
+
+        // 'pong' 시청자 uid, 현재 시간과 함께 저장 or 기존 데이터 시간 갱신
+        channel.on("broadcast", { event: "pong" }, (message) => {
+            const clientId = message.payload?.clientUID;
+            
+            if (!clientId) return; 
+            
+            // uid + 현재 시간 추가 및 갱신 
+            setAudience((prev) => {
+                const now = Date.now();
+                const updated = { ...prev };
+
+                updated[clientId] = now;
+
+                return updated;
+            });
+        });
+
+
+    };
+
+
+    // 채널 비활성화 및 리소스 정리
+    const deactivateChannel = () => {
+        
+        if (pingChannel) {
+            // 채널 파괴
+            supabase.removeChannel(pingChannel);  
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current); 
+                intervalRef.current = null;
+            }            
+            setPingChannel(null); 
+            console.log("시청자 수 채널 삭제 완료");
+        }
+    };
+    
+
+    // 브라우저 종료시 리소스 정리
+    useEffect(() => {
+       window.addEventListener("beforeunload", deactivateChannel);
+
+        return () => {
+            window.removeEventListener("beforeunload", deactivateChannel);
+            deactivateChannel(); 
+        };
+    }, [pingChannel]);
+
+    return { activateChannel, deactivateChannel };
+};
+
+export default useAudienceCnt;

--- a/src/app/_hooks/studio/audience/useAudienceCnt.tsx
+++ b/src/app/_hooks/studio/audience/useAudienceCnt.tsx
@@ -18,7 +18,7 @@ const useAudienceCnt = (payload: useAudienceCntPayload) => {
     const [audience, setAudience] = useState<Record<string, number>>({});  // 시청자 dto 저장
     const [pingChannel, setPingChannel] = useState<RealtimeChannel | null>(null); // 채널 저장
 
-    const TIME = 10 * 1000;
+    const TIME = 7.5 * 1000;
 
     // db 업데이트
     const updateAudienceCnt = async (cnt: number) => {
@@ -106,7 +106,7 @@ const useAudienceCnt = (payload: useAudienceCntPayload) => {
             console.log("시청자 수 채널 삭제 완료");
         }
     };
-    
+
 
     // 브라우저 종료시 리소스 정리
     useEffect(() => {

--- a/src/app/_hooks/studio/useStudioManager.client.tsx
+++ b/src/app/_hooks/studio/useStudioManager.client.tsx
@@ -1,9 +1,11 @@
 import { useRef, useState } from 'react';
 import { audioControl } from './media/audioControls';
 import type * as AgoraRTCType from 'agora-rtc-sdk-ng';
+import useAudienceCnt from './audience/useAudienceCnt';
 import { delClient, initializeClient } from './client/useClient.client';
 import { extractMediaTrack, unpublishMediaTracks } from './media/useMediaTrack';
 import { useStreamingOnOff } from '@/app/_store/queries/streamingSettings/mutation';
+
 
 /**
  * 호스트가 사용하는 스트리밍 훅
@@ -29,6 +31,7 @@ const useStudioManager = (uid: string) => {
   }); // 오디오 컨트롤 훅
 
   const { onMutation, offMutation } = useStreamingOnOff(uid);
+  const { activateChannel, deactivateChannel } = useAudienceCnt({ host_uid:uid });
 
   // 사용법 addTrackShare():스크린 + 마이크 / addTrackShare("mic"):마이크 / addTrackShare("screen"): 스크린
   const addTrackShare = (type: mediaResource = 'all') =>
@@ -55,6 +58,7 @@ const useStudioManager = (uid: string) => {
     try {
       await initializeClient({ APP_ID, channel: uid, clientRef, uid });
       await onMutation();
+      activateChannel();
       return true;
     } catch (err: unknown) {
       await delClient(clientRef);
@@ -74,6 +78,7 @@ const useStudioManager = (uid: string) => {
       });
       await delClient(clientRef);
       await offMutation();
+      deactivateChannel
       return true;
     } catch (err: unknown) {
       console.log(err);

--- a/src/app/_hooks/studio/useStudioManager.client.tsx
+++ b/src/app/_hooks/studio/useStudioManager.client.tsx
@@ -78,7 +78,7 @@ const useStudioManager = (uid: string) => {
       });
       await delClient(clientRef);
       await offMutation();
-      deactivateChannel
+      deactivateChannel();
       return true;
     } catch (err: unknown) {
       console.log(err);


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/studioPage/live/audienceCnt` → `studioPage`

<br/>

## ✅ 작업 내용

-  supabase broadcast 기능을 활용하여 시청자들에게 10초마다 핑을 전송하고 응답을 확인
- 시청자들은 핑을 받은 후 자신의 uid를 호스트에게 다시 전달
- 호스트는 전달받은 uid를 현재 시간과 함께 저장
- 다음 핑 전송 시, (현재 시간 - 저장된 시간) < 제한 시간 조건을 만족하지 않는 uid를 제외하여 시청자 수를 갱신
- 시청자 갱신 시간 7.5초 (체감 상 15초 반영)

<br/>

## 🌠 이미지 첨부
상단에 두 페이지는 로그인한 페이지(chrome)이고 하단에 한 페이지는 로그인을 하지 않은 페이지입니다(firefox)

**같은 uid를 가지고 있으면 시청자 수에 반영 안됨**
![시청자2](https://github.com/user-attachments/assets/75e6630e-8872-4322-b7e9-e58d62812b7b)
<br/>
**시청자 나감 2명 -> 1명**
![시청자1](https://github.com/user-attachments/assets/8cd1abae-e5c1-41c6-bc4c-8732d465c817)


## ✏️ 앞으로의 과제

- livePage 팔로워 버튼/ 팔로워 수 연동
- livePage 로그인하지 않고 시청할 시 방송시간이 안 흘러가는 오류 수정
- 썸네일 이미지 저장 스토리지 만들기


<br/>

## 📌 이슈 링크

- [feat/studioPage/live/audienceCnt #95]
