### PR TITLE
feat(livePage-chat): 닉네임 클릭시 채널 페이지 이동 & 사용자별 닉네임 색상 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.47.3",
-        "@tanstack/react-query": "^5.62.15",
+        "@tanstack/react-query": "^5.63.0",
         "agora-rtc-sdk-ng": "^4.23.0",
         "axios": "^1.7.9",
         "date-fns": "^4.1.0",
@@ -3088,9 +3088,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.62.15",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.15.tgz",
-      "integrity": "sha512-wT20X14CxcWY8YLJ/1pnsXn/y1Q2uRJZYWW93PWRtZt+3/JlGZyiyTcO4pGnqycnP7CokCROAyatsraosqZsDA==",
+      "version": "5.62.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.16.tgz",
+      "integrity": "sha512-9Sgft7Qavcd+sN0V25xVyo0nfmcZXBuODy3FVG7BMWTg1HMLm8wwG5tNlLlmSic1u7l1v786oavn+STiFaPH2g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3098,12 +3098,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.62.15",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.15.tgz",
-      "integrity": "sha512-Ny3xxsOWmEQCFyHiV3CF7t6+QAV+LpBEREiXyllKR4+tStyd8smOAa98ZHmEx0ZNy36M31K8enifB5wTSYAKJw==",
+      "version": "5.63.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.63.0.tgz",
+      "integrity": "sha512-QWizLzSiog8xqIRYmuJRok9VELlXVBAwtINgVCgW1SNvamQwWDO5R0XFSkjoBEj53x9Of1KAthLRBUC5xmtVLQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.62.15"
+        "@tanstack/query-core": "5.62.16"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.3",
-    "@tanstack/react-query": "^5.62.15",
+    "@tanstack/react-query": "^5.63.0",
     "agora-rtc-sdk-ng": "^4.23.0",
     "axios": "^1.7.9",
     "date-fns": "^4.1.0",

--- a/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
@@ -60,7 +60,7 @@ const ChatBox = ({ nickname, message, id }: ChatProps) => {
   const nicknameColor = getColorFromNickname(nickname);
   return (
     <div aria-label="chat w-full">
-      <button className="px-[6px] py-[4px] text-left">
+      <div className="px-[6px] py-[4px] text-left">
         <button
           className="mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative text-green-500"
           onClick={handleNicknameClick}
@@ -72,7 +72,7 @@ const ChatBox = ({ nickname, message, id }: ChatProps) => {
         <span className="text-[#2e3033] text-left break-words leading-[20px]">
           {message}
         </span>
-      </button>
+      </div>
     </div>
   );
 };

--- a/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
@@ -1,4 +1,7 @@
+"use client";
 import { Message } from "@/app/_types/chat/Chat";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 /**
  * 채팅 창
  */
@@ -9,6 +12,9 @@ type MessageListProps = {
 };
 
 const ChatWindow = ({ messages }: MessageListProps) => {
+  useEffect(() => {
+    console.log("msg:", messages);
+  }, [messages]);
   return (
     <div
       id="chatting-list-container"
@@ -22,7 +28,12 @@ const ChatWindow = ({ messages }: MessageListProps) => {
         <div id="empty-box-forChat" aria-label="빈 박스" />
         <div className="text-[14px]">
           {messages.map((msg, idx) => (
-            <ChatBox key={idx} nickname={msg.nickname} message={msg.message} />
+            <ChatBox
+              key={idx}
+              nickname={msg.nickname}
+              message={msg.message}
+              id={msg.id}
+            />
           ))}
         </div>
       </div>
@@ -35,15 +46,23 @@ export default ChatWindow;
 type ChatProps = {
   nickname: string;
   message: string;
+  id: string;
 };
 //채팅 박스
-const ChatBox = ({ nickname, message }: ChatProps) => {
+const ChatBox = ({ nickname, message, id }: ChatProps) => {
+  const router = useRouter();
+  const handleNicknameClick = () => {
+    router.push(`/channel/${id}`);
+  };
   return (
     <div aria-label="chat w-full">
       <button className="px-[6px] py-[4px] text-left">
-        <span className="mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative text-green-500">
+        <button
+          className="mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative text-green-500"
+          onClick={handleNicknameClick}
+        >
           {nickname}
-        </span>
+        </button>
 
         <span className="text-[#2e3033] text-left break-words leading-[20px]">
           {message}

--- a/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
@@ -2,6 +2,8 @@
 import { Message } from "@/app/_types/chat/Chat";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import { getColorFromNickname } from "@/app/_utils/chat/hashColor";
+
 /**
  * 채팅 창
  */
@@ -54,12 +56,15 @@ const ChatBox = ({ nickname, message, id }: ChatProps) => {
   const handleNicknameClick = () => {
     router.push(`/channel/${id}`);
   };
+
+  const nicknameColor = getColorFromNickname(nickname);
   return (
     <div aria-label="chat w-full">
       <button className="px-[6px] py-[4px] text-left">
         <button
           className="mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative text-green-500"
           onClick={handleNicknameClick}
+          style={{ color: nicknameColor }}
         >
           {nickname}
         </button>

--- a/src/app/(route)/live/[host_uid]/components/Chat/Input.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/Input.client.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import SvgIcon from "../../../../../_components/SVGIcon.server";
-
 /**
  * 채팅 입력란
  */
@@ -9,7 +8,6 @@ type MessageInputProps = {
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onSend: () => void;
 };
-
 const ChatInput = ({ value, onChange, onSend }: MessageInputProps) => {
   return (
     <div

--- a/src/app/_hooks/useChat.ts
+++ b/src/app/_hooks/useChat.ts
@@ -8,9 +8,10 @@ export const useChat = (roomId: string) => {
   const supabase = createClient();
   const [messages, setMessages] = useState<Message[]>([]);
   const [nickname, setNickname] = useState<string>("");
+  const [userId, setUserId] = useState<string>("");
 
   useEffect(() => {
-    const fetchUserNickname = async () => {
+    const fetchUserDetails = async () => {
       const { data: userData, error: userError } =
         await supabase.auth.getUser();
 
@@ -20,6 +21,7 @@ export const useChat = (roomId: string) => {
       }
 
       const userId = userData.user.id;
+      setUserId(userId);
 
       const { data: userProfile, error: profileError } = await supabase
         .from("users")
@@ -35,7 +37,7 @@ export const useChat = (roomId: string) => {
       setNickname(userProfile.nickname);
     };
 
-    fetchUserNickname();
+    fetchUserDetails();
   }, [supabase]);
 
   // 채널 구독
@@ -54,13 +56,13 @@ export const useChat = (roomId: string) => {
   }, [roomId, supabase]);
 
   const sendMessage = async (message: string) => {
-    if (!nickname) {
-      console.error("닉네임이 설정되지 않았습니다.");
+    if (!nickname || !userId) {
+      console.error("닉네임 또는 사용자 ID가 설정되지 않았습니다.");
       return;
     }
 
     const newMessage: Message = {
-      id: Date.now().toString(),
+      id: userId,
       room_id: roomId,
       nickname,
       message,

--- a/src/app/_utils/chat/hashColor.ts
+++ b/src/app/_utils/chat/hashColor.ts
@@ -1,0 +1,8 @@
+export const getColorFromNickname = (nickname: string): string => {
+  let hash = 0;
+  for (let i = 0; i < nickname.length; i++) {
+    hash = nickname.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const color = `hsl(${hash % 360}, 70%, 60%)`; // HSL 색상 생성 (밝고 다양하게)
+  return color;
+};

--- a/src/app/_utils/chat/hashColor.ts
+++ b/src/app/_utils/chat/hashColor.ts
@@ -3,6 +3,21 @@ export const getColorFromNickname = (nickname: string): string => {
   for (let i = 0; i < nickname.length; i++) {
     hash = nickname.charCodeAt(i) + ((hash << 5) - hash);
   }
-  const color = `hsl(${hash % 360}, 70%, 60%)`; // HSL 색상 생성 (밝고 다양하게)
+
+  // HSL 값 계산
+  let hue = hash % 360;
+
+  if (hue >= 50 && hue <= 60) {
+    hue = (hue + 70) % 360;
+  }
+
+  const saturation = 70;
+  let lightness = 60;
+
+  if (lightness >= 90) {
+    lightness = 60;
+  }
+
+  const color = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
   return color;
 };


### PR DESCRIPTION


## 🚀 반영 브랜치
`livePage-chat` → `livePage`

<br/>

## ✅ 작업 내용

- 사용자의 uid를 통해 채팅화면의 닉네임을 누를 시 사용자의 채널 페이지로 이동하도록 라우팅 해주었습니다.
- 해시값을 통해 사용자별 고유 색상을 추가해 주었습니다(잘 보이는 노란색,흰색 제외)

<br/>

## 🌠 이미지 첨부

<img width="170" alt="image" src="https://github.com/user-attachments/assets/c851ebcb-be66-427b-8cbf-3a255cf531d9" />

<br/>

## ✏️ 앞으로의 과제

- 메인페이지 방송 카드->스트리밍 룸 연동
- 메인페이지 디테일 ui 변경

<br/>

## 📌 이슈 링크

#60 
