### PR TITLE
feat(livePage-chat): 채팅에서 호스트와 시청자 구분

### DIFF
--- a/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
@@ -66,10 +66,11 @@ const ChatBox = ({ nickname, message, id, roomId }: ChatProps) => {
     <div aria-label="chat w-full">
       <div className="px-[6px] py-[4px] text-left flex">
         <button
-          className={`mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative border-2 flex items-center ${
-            isBroadcaster ? "text-[#3a4338] font-bold" : `${nicknameColor}`
-          }`}
+          className={`mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative border-2 flex items-center`}
           onClick={handleNicknameClick}
+          style={{
+            color: isBroadcaster ? "#3a4338" : nicknameColor, // 조건에 따라 색상 적용
+          }}
         >
           {isBroadcaster && (
             <span className={`font-bold text-[#1bb373] mr-1 text-xl`}>

--- a/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
@@ -3,7 +3,7 @@ import { Message } from "@/app/_types/chat/Chat";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { getColorFromNickname } from "@/app/_utils/chat/hashColor";
-
+import { IoShieldCheckmarkSharp } from "react-icons/io5";
 /**
  * 채팅 창
  */
@@ -11,9 +11,10 @@ import { getColorFromNickname } from "@/app/_utils/chat/hashColor";
 //프롭스는 나중에
 type MessageListProps = {
   messages: Message[];
+  roomId: string;
 };
 
-const ChatWindow = ({ messages }: MessageListProps) => {
+const ChatWindow = ({ messages, roomId }: MessageListProps) => {
   useEffect(() => {
     console.log("msg:", messages);
   }, [messages]);
@@ -35,6 +36,7 @@ const ChatWindow = ({ messages }: MessageListProps) => {
               nickname={msg.nickname}
               message={msg.message}
               id={msg.id}
+              roomId={roomId}
             />
           ))}
         </div>
@@ -49,23 +51,31 @@ type ChatProps = {
   nickname: string;
   message: string;
   id: string;
+  roomId: string;
 };
 //채팅 박스
-const ChatBox = ({ nickname, message, id }: ChatProps) => {
+const ChatBox = ({ nickname, message, id, roomId }: ChatProps) => {
   const router = useRouter();
   const handleNicknameClick = () => {
     router.push(`/channel/${id}`);
   };
 
   const nicknameColor = getColorFromNickname(nickname);
+  const isBroadcaster = id === roomId;
   return (
     <div aria-label="chat w-full">
-      <div className="px-[6px] py-[4px] text-left">
+      <div className="px-[6px] py-[4px] text-left flex">
         <button
-          className="mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative text-green-500"
+          className={`mr-[4px] leading-[18px] m-[-2px_0] p-[2px_4px_2px_2px] relative border-2 flex items-center ${
+            isBroadcaster ? "text-[#3a4338] font-bold" : `${nicknameColor}`
+          }`}
           onClick={handleNicknameClick}
-          style={{ color: nicknameColor }}
         >
+          {isBroadcaster && (
+            <span className={`font-bold text-[#1bb373] mr-1 text-xl`}>
+              <IoShieldCheckmarkSharp />
+            </span>
+          )}
           {nickname}
         </button>
 

--- a/src/app/(route)/live/[host_uid]/widget/Chat.client.tsx
+++ b/src/app/(route)/live/[host_uid]/widget/Chat.client.tsx
@@ -33,7 +33,7 @@ const ChatLayout = ({ roomId }: { roomId: string }) => {
       className="bg-white flex relative flex-col min-h-0"
     >
       <ChatHeader ChatFold={toggleChat} />
-      <ChatWindow messages={messages} />
+      <ChatWindow messages={messages} roomId={roomId} />
       <ChatInput
         value={newMessage}
         onChange={(e) => setNewMessage(e.target.value)}

--- a/src/app/_utils/chat/hashColor.ts
+++ b/src/app/_utils/chat/hashColor.ts
@@ -14,8 +14,8 @@ export const getColorFromNickname = (nickname: string): string => {
   const saturation = 70;
   let lightness = 60;
 
-  if (lightness >= 90) {
-    lightness = 60;
+  if (lightness < 30) {
+    lightness = 40;
   }
 
   const color = `hsl(${hue}, ${saturation}%, ${lightness}%)`;


### PR DESCRIPTION


## 🚀 반영 브랜치
`livePage-chat` → `livePage`

<br/>

## ✅ 작업 내용

호스트인 경우 아이콘,색상,bold처리를 통해 다른 시청자들과 차이점을 주었습니다.

<br/>

## 🌠 이미지 첨부
- 호스트인 경우
<img width="355" alt="image" src="https://github.com/user-attachments/assets/9b6c6d4e-c868-470f-b114-41e9c2e25d13" />

-일반 시청자 인 경우
<img width="353" alt="image" src="https://github.com/user-attachments/assets/edad1e66-1e74-412a-8800-038064b93a8b" />

<br/>

## ✏️ 앞으로의 과제

- 메인페이지 ui 수정
- 방송 카드-> 스트리밍 페이지 연동

<br/>

## 📌 이슈 링크
#106 
