### PR TITLE
feat(ChatHeader): 채팅 헤더 버튼 라우트 경로에 따른 조건부 렌더링 구현, 빌드 에러 해결

### DIFF
--- a/src/app/(route)/live/[host_uid]/components/Chat/Header.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/Header.client.tsx
@@ -1,37 +1,65 @@
-import React from 'react'
-import SvgIcon from '../../../../../_components/SVGIcon.server'
+import React from 'react';
+import SvgIcon from '../../../../../_components/SVGIcon.server';
+import { usePathname } from 'next/navigation';
 
 /**
  * 채팅 헤더
  */
 
-interface ChatHeaderProps{
-    ChatFold: () => void
+interface ChatHeaderProps {
+  ChatFold: () => void;
+  uid: string;
 }
 
 const ChatHeader = (props: ChatHeaderProps) => {
-    const { ChatFold } = props;
+  const { ChatFold, uid } = props;
+  const pathname = usePathname();
 
-    return (
-        
-        <div id="chatting-header-container" className="h-[44px] relative box-border">
-            <h2 className="flex items-center justify-center bg-[#fff] border border-solid border-t-[#0000000f] border-b-[#0000000f] border-l-0 border-r-0 text-[#2e3033] text-[15px] font-normal h-full px-11 relative z-10">
-                채팅
-            </h2>
-            
-            <div className=" absolute top-0 z-[100] box-border w-[44px] h-[44px]">
-                <button onClick={ChatFold} type="button" aria-label="채팅 접기" className="text-[#666] overflow-hidden p-[8px] w-[inherit] h-[inherit]">
-                    <SvgIcon name="ChatFold" width={28} height={28} className="rounded-lg hover:bg-[#58585820] hover:text-black"/>
-                </button>
-            </div>  
+  return (
+    <div
+      id="chatting-header-container"
+      className="h-[44px] relative box-border"
+    >
+      <h2 className="flex items-center justify-center bg-[#fff] border border-solid border-t-[#0000000f] border-b-[#0000000f] border-l-0 border-r-0 text-[#2e3033] text-[15px] font-normal h-full px-11 relative z-10">
+        채팅
+      </h2>
 
-            <div className="right-0 absolute top-0 z-[100] box-border w-[44px] h-[44px]">
-                <button type="button" aria-label="채팅 접기" className="text-[#666] overflow-hidden p-[8px] w-[inherit] h-[inherit]">
-                    <SvgIcon name="ChatOption" width={20} height={28} className="rounded-lg hover:bg-[#58585820] hover:text-black"/>
-                </button>
-            </div>  
-        </div>
-    )
-}
+      {pathname === `/live/${uid}` && (
+        <>
+          <div className=" absolute top-0 z-[100] box-border w-[44px] h-[44px]">
+            <button
+              onClick={ChatFold}
+              type="button"
+              aria-label="채팅 접기"
+              className="text-[#666] overflow-hidden p-[8px] w-[inherit] h-[inherit]"
+            >
+              <SvgIcon
+                name="ChatFold"
+                width={28}
+                height={28}
+                className="rounded-lg hover:bg-[#58585820] hover:text-black"
+              />
+            </button>
+          </div>
 
-export default ChatHeader
+          <div className="right-0 absolute top-0 z-[100] box-border w-[44px] h-[44px]">
+            <button
+              type="button"
+              aria-label="채팅 접기"
+              className="text-[#666] overflow-hidden p-[8px] w-[inherit] h-[inherit]"
+            >
+              <SvgIcon
+                name="ChatOption"
+                width={20}
+                height={28}
+                className="rounded-lg hover:bg-[#58585820] hover:text-black"
+              />
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ChatHeader;

--- a/src/app/(route)/live/[host_uid]/widget/Chat.client.tsx
+++ b/src/app/(route)/live/[host_uid]/widget/Chat.client.tsx
@@ -1,29 +1,29 @@
 // ChatLayout.tsx
-"use client";
+'use client';
 
-import useScreenControl from "@/app/_store/live/useScreenControl";
-import ChatWindow from "../components/Chat/ChatWindow.client";
-import ChatHeader from "../components/Chat/Header.client";
-import ChatInput from "../components/Chat/Input.client";
-import { useChat } from "@/app/_hooks/useChat";
-import { CSSProperties, useState } from "react";
+import useScreenControl from '@/app/_store/live/useScreenControl';
+import ChatWindow from '../components/Chat/ChatWindow.client';
+import ChatHeader from '../components/Chat/Header.client';
+import ChatInput from '../components/Chat/Input.client';
+import { useChat } from '@/app/_hooks/useChat';
+import { CSSProperties, useState } from 'react';
 
 const ChatLayout = ({ roomId }: { roomId: string }) => {
   const { isChatOpen, chatPosition, toggleChat } = useScreenControl();
   const { messages, sendMessage } = useChat(roomId);
-  const [newMessage, setNewMessage] = useState("");
+  const [newMessage, setNewMessage] = useState('');
 
   if (!isChatOpen) return null;
 
   const viewChatStyle: CSSProperties = {
-    width: chatPosition === "side" ? "353px" : "auto",
-    flex: chatPosition === "side" ? undefined : "1",
+    width: chatPosition === 'side' ? '353px' : 'auto',
+    flex: chatPosition === 'side' ? undefined : '1',
   };
 
   const handleSendMessage = async () => {
     if (!newMessage.trim()) return;
     await sendMessage(newMessage);
-    setNewMessage("");
+    setNewMessage('');
   };
 
   return (
@@ -32,7 +32,7 @@ const ChatLayout = ({ roomId }: { roomId: string }) => {
       style={viewChatStyle}
       className="bg-white flex relative flex-col min-h-0"
     >
-      <ChatHeader ChatFold={toggleChat} />
+      <ChatHeader ChatFold={toggleChat} uid={roomId} />
       <ChatWindow messages={messages} />
       <ChatInput
         value={newMessage}

--- a/src/app/_components/Header/Header.server.tsx
+++ b/src/app/_components/Header/Header.server.tsx
@@ -1,13 +1,13 @@
-"use client";
+'use client';
 
-import Image from "next/image";
-import Link from "next/link";
-import React, { useEffect, useState } from "react";
-import ExpandNavButton from "./ExpandNavButton.client";
-import LoginButton from "./LoginButton.client";
-import ProfileBtn from "./ProfileBtn";
-import { createClient } from "@/app/_utils/supabase/client";
-import LoginModal from "../LoginModal/LoginModal.client";
+import Image from 'next/image';
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
+import ExpandNavButton from './ExpandNavButton.client';
+import LoginButton from './LoginButton.client';
+import ProfileBtn from './ProfileBtn';
+import { createClient } from '@/app/_utils/supabase/client';
+import LoginModal from '../LoginModal/LoginModal.client';
 const Header = () => {
   const supabase = createClient();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -17,7 +17,6 @@ const Header = () => {
     const checkLoginStatus = async () => {
       const {
         data: { user },
-        error,
       } = await supabase.auth.getUser();
 
       if (user) {
@@ -34,9 +33,9 @@ const Header = () => {
     <header className="bg-[#222] fixed flex justify-between items-center px-[20px] py-[10px] w-full z-40 ">
       <div className="flex items-center gap-2">
         <ExpandNavButton />
-        <Link href={"/"}>
+        <Link href={'/'}>
           <Image
-            src={"/studioPage/WhiteLogo.svg"}
+            src={'/studioPage/WhiteLogo.svg'}
             width={74}
             height={26}
             alt="Logo"


### PR DESCRIPTION
## 🚀 반영 브랜치
`studioPage` → `develop`

<br/>

## ✅ 작업 내용

어떤 부분이 구현되었는지 설명해주세요

<br/>

## 🌠 이미지 첨부

- 스튜디오 페이지
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/f47b3377-8678-4ffb-89ae-0726a82f3720" />

- 라이브 페이지
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/db9195c4-6e35-46b1-a793-b9324c2602c9" />
