### PR TITLE
Fix(livePage/bug): 테스트 버그 픽스 및 일부 기능 개선

### DIFF
--- a/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/ChatWindow.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Message } from "@/app/_types/chat/Chat";
-import { useRouter } from "next/navigation";
+// import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { getColorFromNickname } from "@/app/_utils/chat/hashColor";
 import { IoShieldCheckmarkSharp } from "react-icons/io5";
@@ -38,7 +38,7 @@ const ChatWindow = ({ messages, roomId }: MessageListProps) => {
     }
   };
 
-  // 스크롤 상태 가져오기기
+  // 스크롤 상태 가져오기
   const getScrollState = () => {
     const chatFrame = chatFrameRef.current;
     if (chatFrame) {
@@ -106,9 +106,10 @@ type ChatProps = {
 
 //채팅 박스
 const ChatBox = ({ nickname, message, id, roomId }: ChatProps) => {
-  const router = useRouter();
+  // const router = useRouter();
   const handleNicknameClick = () => {
-    router.push(`/channel/${id}`);
+    // router.push(`/channel/${id}`);
+    window.open(`/channel/${id}`, '_blank');
   };
 
   const nicknameColor = getColorFromNickname(nickname);

--- a/src/app/(route)/live/[host_uid]/widget/LiveDetails.client.tsx
+++ b/src/app/(route)/live/[host_uid]/widget/LiveDetails.client.tsx
@@ -104,7 +104,7 @@ const HostInfoCompo = (props:HostInfoProps) => {
     const { followMutate, unfollowMutate } = useFollowAction();
     const [followState, setFollowState] = useState<boolean>(false);
 
-    const followerCount = error || isLoading || !data ? "n" : data.length;
+    const followerCount = error || isLoading || !data ? "0" : data.length;
 
     const onClickHandler = () => {
         if (!uid || uid === host_uid || isLoading || error) return;

--- a/src/app/(route)/live/[host_uid]/widget/VideoPlayer.client.tsx
+++ b/src/app/(route)/live/[host_uid]/widget/VideoPlayer.client.tsx
@@ -90,7 +90,7 @@ const VideoPlayer = (props:VideoPlayerProps) => {
                 aria-label='비디오 대체 박스' 
                 id='streaming-video'
                 ref={screenElRef} 
-                style={{objectFit:"contain"}} 
+                style={{objectFit:"scale-down"}} 
                 muted 
                 className='w-full h-full'
               >

--- a/src/app/_hooks/live/useLiveManager.tsx
+++ b/src/app/_hooks/live/useLiveManager.tsx
@@ -66,7 +66,7 @@ const useLiveManager = (payload: useStreamforStudioPayload) => {
                 screenElRef.current.muted = true;
                 remoteScreenTrack.play(screenElRef.current);     
                 screenElRef.current.play();
-                screenElRef.current.style.objectFit = "contain"
+                screenElRef.current.style.objectFit = "scale-down"
                 //비율
                 await remoteScreenTrack.on('video-state-changed', () => {
                     const stats = remoteScreenTrack.getStats();


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/livePage/bug` → `develop`

<br/>

## ✅ 작업 내용

- 팔로워가 없을 시 n명 -> 0명 수정
- video 속성 objectFit: contain -> scale-down로 변경하여  리사이즈시 비디오 비율이 깨지는 문제 수정
- 치지직이나 유튜브는 PIP 모드를 제공하여 다른 채널로 이동해도 방송이 중단되지 않지만, 현재 구현이 불가능하고 방송 흐름을 위해 새 창 열기로 동작 변경  
- studioPage에서도 동일한 채팅 기능을 사용하고 있어 채팅을 클릭하면 라우팅이 변경되어 방송이 중단될 가능성이 있음. 때문에 새창 여는 동작으로 수정 (기존 코드는 혹시 몰라서 주석처리함)


<br/>

## 🌠 이미지 첨부


## ✏️ 앞으로의 과제

- 마이크 최소 소리 필터링 
![image](https://github.com/user-attachments/assets/004e0801-270e-4071-8153-f1a7b6a2083a)
오류 해결

<br/>

## 📌 이슈 링크

- [fix/livePage/bug #137 ]
