### PR TITLE
fix(livePage/bug): 오디오 기능/크로스 브라우징 문제 해결

### DIFF
--- a/src/app/(route)/live/[host_uid]/components/Chat/Input.client.tsx
+++ b/src/app/(route)/live/[host_uid]/components/Chat/Input.client.tsx
@@ -14,7 +14,12 @@ const ChatInput = ({ value, onChange, onSend, client_uid }: MessageInputProps) =
   const onPressEnter = (e:React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      if(!isComposing) {
+      if(navigator.userAgent.includes("Firefox")) {
+        if(!e.nativeEvent.isComposing) {
+          onSend();
+        }
+      }
+      else if(!isComposing) {
         onSend();
       }
     }
@@ -38,8 +43,14 @@ const ChatInput = ({ value, onChange, onSend, client_uid }: MessageInputProps) =
           value={value}
           onChange={onChange}
           onKeyDown={onPressEnter}
-          onCompositionStart={() => setIsComposing(true)}
-          onCompositionEnd={() => setIsComposing(false)}
+          onCompositionStart={() => {
+            if(navigator.userAgent.includes("Firefox")) return;
+            setIsComposing(true)
+          }}
+          onCompositionEnd={() => {
+            if(navigator.userAgent.includes("Firefox")) return;
+            setIsComposing(false)}
+          }
           placeholder="채팅을 입력해주세요"
         />
       </div>

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingArea/StreamingButtonList.client.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/StreamingArea/StreamingButtonList.client.tsx
@@ -115,7 +115,7 @@ const StreamingButtonList = () => {
             type="range"
             step={1}
             min={0}
-            max={1000}
+            max={100}
             value={audioVolume.mic}
             onChange={(e) => controlAudio('mic', Number(e.currentTarget.value))}
             className="w-full"
@@ -130,7 +130,7 @@ const StreamingButtonList = () => {
             type="range"
             step={1}
             min={0}
-            max={1000}
+            max={100}
             value={audioVolume.screen}
             onChange={(e) =>
               controlAudio('screen', Number(e.currentTarget.value))


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/livePage/bug` → `develop`

<br/>

## ✅ 작업 내용

- E2E 테스트 중 발생한 오디오 소리 버그는 노트북에서 출력된 소리를 마이크가 다시 수음하여 그대로 출력한 것이 원인이었습니다.
실제 라이브 진행 시, 아주 작은 소리도 마이크에 입력되는 것을 확인했습니다.
이를 해결하기 위해 필터를 추가했으며, AudioContext API를 사용해 고주파와 저주파 범위를 설정하고 특정 음역대를 무시하는 필터를 적용했습니다.

- 기존 오디오 볼륨 범위가 0~1000으로 설정되어 있어 적절한 오디오 볼륨을 설정하기 어려웠습니다. 최대치를 100으로 테스트한 결과 충분히 큰 볼륨으로 확인되어, 최대치를 낮추어 범위를 조정했습니다.

- macOS를 위한 composing 상태 관리 로직이 Firefox에서 IME(입력기) 사용 시 오류를 발생시키는 것을 확인했습니다 Firefox에서는 composing 상태를 직접 사용하는 대신, 이벤트를 기반으로 처리하도록 개선했습니다.


<br/>

## 🌠 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## ✏️ 앞으로의 과제


<br/>

## 📌 이슈 링크

- [fix/livePage/bug #137]