### PR TITLE
fix(StudioPage): follower_details profile_img 속성값 오타 수정

### DIFF
--- a/src/app/api/user/follow/[uid]/route.ts
+++ b/src/app/api/user/follow/[uid]/route.ts
@@ -7,7 +7,7 @@ interface Follower {
   follower_uid: string;
   following_uid: string;
   follower_nickname: string;
-  follower_profile_img: null | string;
+  profile_img: null | string;
   is_following_user: boolean;
   status: 'active' | 'block';
 }
@@ -37,7 +37,7 @@ export async function GET(
     follower: {
       uid: item.follower_uid,
       nickname: item.follower_nickname,
-      profile_img: item.follower_profile_img || '/userImage.webp',
+      profile_img: item.profile_img || '/userImage.webp',
       is_following_user: item.is_following_user,
     },
   }));


### PR DESCRIPTION
## 🚀 반영 브랜치
`studio` → `dev`

<br/>

## ✅ 작업 내용

- 데이터베이스 속성과 정의한 interface key값과 일치하지않아 발생한 문제입니다.
- key 값을 수정하여 해결하였습니다.

<br/>

## 🌠 이미지 첨부

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/20cb8dba-9183-4fa3-875d-b34266175fea" />

## 📌 이슈 링크

- Close #147 
