### PR TITLE
feat(studio): zod 스키마를 이용한 태그 문자 검증 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.4.0",
+        "zod": "^3.24.1",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
@@ -8999,6 +9000,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",
+    "zod": "^3.24.1",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/src/app/(route)/studio/[uid]/(route)/live/_components/Settings/CellComponents/CellTags.tsx
+++ b/src/app/(route)/studio/[uid]/(route)/live/_components/Settings/CellComponents/CellTags.tsx
@@ -1,64 +1,20 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import SeacrhIcon from '@public/studioPage/Search.svg';
 import useStreamingSettings from '@/app/_store/stores/studio/useStreamingSettings';
 import DeleteIcon from '@public/studioPage/Delete.svg';
 import ErrorAlertIcon from '@public/studioPage/ErrorAlert.svg';
+import useTagValidation from '@/app/_hooks/studio/useTagValidation';
 
 const CellTags = ({ tags }: { tags: string[] }) => {
   const [isFocus, setIsFocus] = useState(false);
-  const [text, setText] = useState('');
-  const [tagErrorType, setTagErrorType] = useState<{
-    lengthError: boolean;
-    duplicateError: boolean;
-  }>({
-    lengthError: false,
-    duplicateError: false,
-  });
-  const { data, setPushTags, setDeleteTags } = useStreamingSettings();
-
-  useEffect(() => {
-    if (data.tags.length < 5) {
-      setTagErrorType((prev) => ({ ...prev, lengthError: false }));
-    }
-  }, [data]);
-
-  useEffect(() => {
-    if (tags.length > 0) {
-      tags.forEach((item) => {
-        if (!data.tags.includes(item)) {
-          setPushTags(item);
-        }
-      });
-    }
-  }, [tags, data.tags]);
+  const { data, setDeleteTags } = useStreamingSettings();
+  const { text, tagError, handleInputChange, handleSubmit } = useTagValidation(tags);
 
   return (
     <div className="flex flex-col w-full">
-      <form
-        className="flex gap-[10px] w-full"
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (data.tags.includes(text)) {
-            setText('');
-            return setTagErrorType({
-              lengthError: false,
-              duplicateError: true,
-            });
-          }
-          if (data.tags.length === 5) {
-            setText('');
-            return setTagErrorType({
-              lengthError: true,
-              duplicateError: false,
-            });
-          }
-          setTagErrorType({ lengthError: false, duplicateError: false });
-          setPushTags(text);
-          setText('');
-        }}
-      >
+      <form className="flex gap-[10px] w-full" onSubmit={handleSubmit}>
         <div
           className={`bg-white border p-[9px_14px] inline-flex rounded-[5px] items-center gap-1 w-full h-[40px] ${
             isFocus ? 'border-[#4e41db]' : 'border-[#ddd] hover:border-[#aaa]'
@@ -69,41 +25,25 @@ const CellTags = ({ tags }: { tags: string[] }) => {
             placeholder="태그 입력 후 Enter 또는 추가 버튼을 클릭해주세요."
             type="text"
             autoComplete="off"
-            color="#222"
             className="text-[14px] focus:outline-none w-full"
             onFocus={() => setIsFocus(true)}
             onBlur={() => setIsFocus(false)}
-            onChange={(e) => setText(e.target.value)}
+            onChange={handleInputChange}
             value={text}
           />
         </div>
         <button
           className="bg-[#4e41db1a] min-w-[64px] h-[40px] text-[13px] font-extrabold rounded-[7px]"
-          style={{
-            color: text ? '#4e41db' : '#4e41db4d',
-          }}
+          style={{ color: text ? '#4e41db' : '#4e41db4d' }}
         >
           추가
         </button>
       </form>
 
-      {tagErrorType.lengthError && (
-        <p
-          role="alert"
-          className="flex gap-1 text-[#ff393e] items-center text-[12px] mt-[10px] ml-[3px]"
-        >
+      {tagError && (
+        <p role="alert" className="flex gap-1 text-[#ff393e] items-center text-[12px] mt-[10px] ml-[3px] font-semibold">
           <ErrorAlertIcon />
-          태그는 5개까지 등록 가능합니다.
-        </p>
-      )}
-
-      {tagErrorType.duplicateError && (
-        <p
-          role="alert"
-          className="flex gap-1 text-[#ff393e] items-center text-[12px] mt-[10px] ml-[3px]"
-        >
-          <ErrorAlertIcon />
-          이미 등록된 태그입니다.
+          {tagError}
         </p>
       )}
 
@@ -125,8 +65,10 @@ const CellTags = ({ tags }: { tags: string[] }) => {
         ))}
       </div>
 
-      <ul className="text-[#697183] text-[13px] list-disc	ml-[20px] mt-[10px]">
+      <ul className="text-[#697183] text-[13px] list-disc ml-[20px] mt-[10px]">
         <li>공백 및 특수 문자 없이 15자까지 입력할 수 있습니다.</li>
+        <li className="ml-4"> ex) ㅁㄴㅇ, @안녕, 하 이 → ❌</li>
+        <li className="ml-4"> ex) 안녕, asd, 123123 → ✅</li>
         <li>등록한 순서대로 방송 정보에 노출됩니다.</li>
       </ul>
     </div>

--- a/src/app/_hooks/studio/useTagValidation.ts
+++ b/src/app/_hooks/studio/useTagValidation.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import useStreamingSettings from '@/app/_store/stores/studio/useStreamingSettings';
+
+// Zod 스키마 정의 (최대 15자, 공백 & 특수문자 제한)
+const tagSchema = z
+  .string()
+  .min(1, '태그를 입력해주세요.')
+  .max(15, '태그는 15자까지 입력 가능합니다.')
+  .regex(/^[a-zA-Z0-9가-힣]+$/, '공백 및 특수 문자는 입력할 수 없습니다.');
+
+const useTagValidation = (tags: string[]) => {
+  const [text, setText] = useState('');
+  const [tagError, setTagError] = useState<string | null>(null);
+  const { data, setPushTags } = useStreamingSettings();
+
+  useEffect(() => {
+    if (tags.length > 0) {
+      tags.forEach((item) => {
+        if (!data.tags.includes(item)) {
+          setPushTags(item);
+        }
+      });
+    }
+  }, [tags, data.tags]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+    setTagError(null); // 입력 중 오류 메시지 초기화
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // 1. Zod 검증 실행
+    const validationResult = tagSchema.safeParse(text);
+    if (!validationResult.success) {
+      setTagError(validationResult.error.issues[0].message);
+      return;
+    }
+
+    // 2. 중복 태그 검사
+    if (data.tags.includes(text)) {
+      setTagError('이미 등록된 태그입니다.');
+      return;
+    }
+
+    // 3. 최대 5개 태그 제한
+    if (data.tags.length >= 5) {
+      setTagError('태그는 5개까지 등록 가능합니다.');
+      return;
+    }
+
+    // 4. 모든 조건 통과 시 태그 추가
+    setPushTags(text);
+    setText(''); // 입력창 초기화
+    setTagError(null);
+  };
+
+  return {
+    data,
+    text,
+    tagError,
+    handleInputChange,
+    handleSubmit,
+  };
+};
+
+export default useTagValidation;


### PR DESCRIPTION
## 🚀 반영 브랜치
`studio` → `dev`

<br/>

## ✅ 작업 내용

- zod 스키마를 이용하여 문자 검증을 진행하였습니다.
- `useTagValidation` 훅을 이용하여 headless 컴포넌트를 지향하였습니다.

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/88020107-fab6-4a98-9369-90e2be0fefa3)
![image](https://github.com/user-attachments/assets/00204504-bd70-4542-9a8a-f9eda02b1008)

<br/>

## 📌 이슈 링크

- #154 
