### PR TITLE
feat(channelPage): 삭제 전 확인 모달 추가

### DIFF
--- a/src/app/(route)/channel/[uid]/components/Comment.tsx
+++ b/src/app/(route)/channel/[uid]/components/Comment.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import CommentInput from './CommentInput';
 import { createClient } from '@/app/_utils/supabase/client';
+import ConfirmModal from './ConfirmModal'; 
 
 interface Props {
   nickname: string;
@@ -34,6 +35,7 @@ const Comment = (props: Props) => {
 
   const [loggedInUserId, setLoggedInUserId] = useState<string | null>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const defaultImage = '/channelPage/blank_profile.svg';
 
   useEffect(() => {
@@ -60,9 +62,14 @@ const Comment = (props: Props) => {
     setIsDropdownOpen(false);
   };
 
-  const handleDelete = async () => {
-    await onDelete();
+  const handleDeleteClick = () => {
+    setShowDeleteModal(true); 
     setIsDropdownOpen(false);
+  };
+
+  const confirmDelete = async () => {
+    await onDelete();
+    setShowDeleteModal(false);
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -138,7 +145,7 @@ const Comment = (props: Props) => {
                   수정
                 </button>
                 <button
-                  onClick={handleDelete}
+                  onClick={handleDeleteClick}
                   className="flex w-full text-left font-bold p-2 text-sm text-red-500 hover:bg-gray-100 rounded-lg"
                 >
                   <Image
@@ -153,7 +160,7 @@ const Comment = (props: Props) => {
               </>
             ) : (
               <button
-                className="flex w-full text-left m-auto align-middle font-bold p-2 text-sm  hover:bg-gray-100 rounded-lg"
+                className="flex w-full text-left m-auto align-middle font-bold p-2 text-sm hover:bg-gray-100 rounded-lg"
                 onClick={() => alert('신고 기능은 준비 중입니다.')}
               >
                 <Image
@@ -169,6 +176,14 @@ const Comment = (props: Props) => {
           </div>
         )}
       </div>
+
+      {showDeleteModal && (
+        <ConfirmModal
+          message="정말로 이 댓글을 삭제할까요?"
+          onConfirm={confirmDelete}
+          onCancel={() => setShowDeleteModal(false)}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/(route)/channel/[uid]/components/ConfirmModal.tsx
+++ b/src/app/(route)/channel/[uid]/components/ConfirmModal.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+
+interface ConfirmModalProps {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmModal: React.FC<ConfirmModalProps> = ({ message, onConfirm, onCancel }) => {
+  return (
+    <div 
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      onClick={onCancel}>
+      <div 
+        className="bg-white p-6 rounded shadow-md max-w-sm w-full"
+        onClick={(e) => e.stopPropagation()}>
+        <p className="mb-10 mt-4 text-md font-semibold flex justify-center">{message}</p>
+        <div className="flex">
+          <button
+            onClick={onCancel}
+            className="w-1/2 mr-2 px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            className="w-1/2 px-4 py-2 bg-[#1bb373] text-white rounded hover:bg-[#15744c]"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/app/(route)/channel/[uid]/detail/[postid]/page.tsx
+++ b/src/app/(route)/channel/[uid]/detail/[postid]/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from '@/app/_utils/supabase/client';
 import Comment from '../../components/Comment';
 import CommentInput from '../../components/CommentInput';
 import Image from 'next/image';
+import ConfirmModal from '../../components/ConfirmModal'; 
 
 interface PostDetail {
   id: number;
@@ -36,10 +37,11 @@ export default function Detail() {
   const [comments, setComments] = useState<CommentType[]>([]);
   const [newComment, setNewComment] = useState<string>('');
   const [loggedInUserId, setLoggedInUserId] = useState<string | null>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const formattedDate = post ? new Date(post.created_at).toLocaleString() : '';
   const defaultImage = '/channelPage/blank_profile.svg';
 
-// 현재 로그인한 사용자 정보 가져오기
+  // 현재 로그인한 사용자 정보 가져오기
   useEffect(() => {
     const fetchLoggedInUser = async () => {
       const supabase = createClient();
@@ -55,7 +57,7 @@ export default function Detail() {
     fetchLoggedInUser();
   }, []);
 
-// 게시글 불러오기
+  // 게시글 불러오기
   useEffect(() => {
     if (!postid) {
       console.log('postid가 없음');
@@ -73,7 +75,8 @@ export default function Detail() {
 
         if (error) {
           console.error('게시글 불러오기 오류:', error);
-        } if (data) {
+        } 
+        if (data) {
           // 작성자 프로필 이미지 가져오기
           const { data: userData, error: userError } = await supabase
             .from('users')
@@ -98,7 +101,7 @@ export default function Detail() {
     fetchPostById();
   }, [postid]);
 
-// 댓글 목록 불러오기
+  // 댓글 목록 불러오기
   const fetchComments = async () => {
     if (!postid) return;
     try {
@@ -143,7 +146,7 @@ export default function Detail() {
     fetchComments();
   }, [postid]);
 
-// 게시글 삭제
+  // 게시글 삭제
   const handleDelete = async () => {
     if (!postid) return;
     try {
@@ -162,6 +165,12 @@ export default function Detail() {
     } catch (err) {
       console.error('게시글 삭제 에러:', err);
     }
+  };
+
+  // 모달창 확인 삭제
+  const confirmDelete = async () => {
+    await handleDelete();
+    setShowDeleteModal(false);
   };
 
   // 댓글 추가
@@ -198,7 +207,6 @@ export default function Detail() {
       console.error('댓글 추가 에러:', err);
     }
   };
-
 
   // 댓글 수정
   const handleCommentEditStart = (id: number) => {
@@ -293,7 +301,7 @@ export default function Detail() {
               수정
             </button>
             <button
-              onClick={handleDelete}
+              onClick={() => setShowDeleteModal(true)}
               className="mt-4 px-4 py-2 bg-gray-100 font-bold text-red-500 rounded-xl hover:bg-gray-200"
             >
               삭제
@@ -363,6 +371,14 @@ export default function Detail() {
         ))}
       </div>
       <div className="h-32" />
+
+      {showDeleteModal && (
+        <ConfirmModal
+          message="정말로 이 글을 삭제할까요?"
+          onConfirm={confirmDelete}
+          onCancel={() => setShowDeleteModal(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/deleteModal` → `dev`

<br/>

## ✅ 작업 내용
글과 댓글이 삭제되기 전에 **정말 삭제할건지** 안내 문구 모달을 띄워 재확인 합니다.

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/cbeb17b0-18d3-4233-90e3-2311cdffc3b6)
<br/>

## ✏️ 앞으로의 과제
- 프로필 삭제 기능 추가

<br/>

## 📌 이슈 링크

- #169 
