### PR TITLE
Fix(streamhook-payload): 스트리밍 훅 payload 롤백

### DIFF
--- a/src/app/(route)/live/[host_uid]/widget/VideoPlayer.client.tsx
+++ b/src/app/(route)/live/[host_uid]/widget/VideoPlayer.client.tsx
@@ -8,6 +8,7 @@ import PlayerOverlay from '../components/VideoPlayer/ETC/PlayerOverlay.client'
 import OpacityAnimation from '@/app/_utils/live/local/useOpacityAnimation.client'
 import useLiveControl from '@/app/_store/stores/live/useLiveControl'
 import useLive from '@/app/_hooks/live/useLive'
+import { useParams } from 'next/navigation'
 
 // 스타일
 import { 
@@ -17,12 +18,15 @@ import {
   containerVideoPlayer_style 
 } from '../style/VideoPlayerStyle'
 
+
 /**
  * 라이브 비디오 플레이어 컴포넌트
  */
 const VideoPlayer = () => {
+  const { host_uid } = useParams<{ host_uid: string }>();
   const isChatOpen = useLiveControl(state => state.screen.state.isChatOpen);
   const isFullOrWide = useLiveControl(state => state.screen.state.isFullOrWide);
+  const streaming_is_active = useLiveControl(state => state.streamRoom.state.is_active);
   
   // 라이브 스트리밍 훅
   const {
@@ -30,7 +34,7 @@ const VideoPlayer = () => {
     audioElRef,
     canvasElRef,
     ratio:[h_rate, w_rate],
-  } = useLive();
+  } = useLive({ streaming_is_active, host_uid });
 
   //마우스 호버 훅
   const { isHover, HoverHandler } = useHoverState({});

--- a/src/app/_hooks/live/useLive.tsx
+++ b/src/app/_hooks/live/useLive.tsx
@@ -3,15 +3,20 @@ import useClientAudience from "./client/useClinetAudience..client";
 import useMediaPublish from "./client/useMediaPublish.client";
 import useMediaControl from "./media/useMediaControl.client";
 import { useEffect, useRef, useState } from "react";
-import useLiveControl from "@/app/_store/stores/live/useLiveControl";
-import { useParams } from "next/navigation";
 
-const useLive = () => {
+interface Payload {
+    host_uid:string;
+    streaming_is_active:boolean;
+};
+
+const useLive = (payload: Payload) => {
+    const { 
+        host_uid,
+        streaming_is_active,
+    } = payload;
+
     const [ratio, setRatio] = useState<[number, number]>([1.83, 0.55]); 
     const updateRatio = (a:number, b:number) => setRatio([a,b]);
-
-    const { host_uid } = useParams<{ host_uid: string }>();
-    const streaming_is_active = useLiveControl(state => state.streamRoom.state.is_active);
 
     // host_uid Agora에서 받는 users의 uid는 스트림을 임의의 number로 바꿔버림 
     // 때문에 기존 uid로 식별 불가능해서 미디어를 받을 때 uid를 따로 저장


### PR DESCRIPTION
## 🚀 반영 브랜치
`fix/streamhook-payload` → `dev`

<br/>

## ✅ 작업 내용

- 이전에 스트리밍 훅을 livePage에서만 사용하기에 리얼타임 데이터를 의존하게 개선 했었습니다.
- 근데 새롭게 추가된 MiniVideo client도 스트리밍 훅을 사용하기에 이전 payload로 롤백해서 두 곳에서 사용할 수 있게 개선했습니다.

<br/>

## 🌠 이미지 첨부


## ✏️ 앞으로의 과제

- 미니 비디오 컴포넌트에 ref를 내리거나 전용 훅을 만들 예정
- P2P연결에 지연이 있기에 미디어 스트림 ref을 사용하는게 나으나, 컴포넌트 분리로 ref를 내리는게 불가능하면 전용 구독 훅을 만들 예정


<br/>

## 📌 이슈 링크

- [fix/streamhook-payload # #188]
