### PR TITLE
Feat(miniVideo/liveScreen): 미니 비디오 동작 개선

### DIFF
--- a/src/app/_components/StreamingArea/MiniVideo.client.tsx
+++ b/src/app/_components/StreamingArea/MiniVideo.client.tsx
@@ -16,16 +16,14 @@ const useVideoRef = ({ is_active, videoTrackRef }: Props) => {
 
   // 2초 단위로 미디어 스트림 확인
   useEffect(() => {
-    if (!is_active) {
-      if(videoElRef.current) 
-        videoElRef.current.srcObject = null; // 비디오 src 초기화
+    if (!is_active && videoElRef.current) {
+      videoElRef.current.srcObject = null; // 비디오 src 초기화
       return;
     }
 
     const interval = setInterval(() => {
       if (!videoTrackRef.current || !videoElRef.current) {
-        limit.current = false;
-        return
+        return limit.current = false;
       };
 
       // 미디어 스트림이 존재하면 videoElRef에 src할당

--- a/src/app/_components/StreamingArea/MiniVideo.client.tsx
+++ b/src/app/_components/StreamingArea/MiniVideo.client.tsx
@@ -1,21 +1,52 @@
 'use client';
 
-import useLive from '@/app/_hooks/live/useLive';
-import { useUID } from '@/app/_store/context/useUid';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type * as AgoraRTCType from 'agora-rtc-sdk-ng';
 
 interface Props {
   is_active: boolean;
-}
+  videoTrackRef:React.RefObject<AgoraRTCType.ILocalVideoTrack | null>;
+};
 
-const MiniVideo = ({ is_active }: Props) => {
+// 미디어 트랙이 있으면 이를 할당한 videoElRef 반환
+const useVideoRef = ({ is_active, videoTrackRef }: Props) => {
+  const videoElRef = useRef<HTMLVideoElement>(null);
+  const limit = useRef<boolean>(false);
+  const SEC = 2 * 1000;
+
+  // 2초 단위로 미디어 스트림 확인
+  useEffect(() => {
+    if (!is_active) {
+      if(videoElRef.current) 
+        videoElRef.current.srcObject = null; // 비디오 src 초기화
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (!videoTrackRef.current || !videoElRef.current) {
+        limit.current = false;
+        return
+      };
+
+      // 미디어 스트림이 존재하면 videoElRef에 src할당
+      
+      videoTrackRef.current.play(videoElRef.current);
+      limit.current = true;
+      
+    }, SEC);
+
+    return () => clearInterval(interval);
+  },[is_active, videoTrackRef, videoElRef, SEC]);
+
+  return {
+    videoElRef,
+  }
+};
+
+
+const MiniVideo = ({ is_active, videoTrackRef }: Props) => {
   const [isHidden, setIsHidden] = useState(false);
-
-  const uid = useUID();
-  const { videoElRef } = useLive({
-    host_uid: uid,
-    streaming_is_active: is_active,
-  });
+  const { videoElRef } = useVideoRef({ is_active, videoTrackRef });
 
   return (
     <>
@@ -31,6 +62,7 @@ const MiniVideo = ({ is_active }: Props) => {
         >
           X
         </button>
+        
         <video muted ref={videoElRef} className="w-[90%] h-[90%] bg-black"></video>
       </div>
 

--- a/src/app/_components/StreamingArea/StreamingButtonList.client.tsx
+++ b/src/app/_components/StreamingArea/StreamingButtonList.client.tsx
@@ -6,10 +6,15 @@ import { useUserStreaming } from '@/app/_store/queries/streamingSettings/query';
 import React, { useState } from 'react';
 import ActionButton from './ActionButton.client';
 import { useStreamingWorker } from '@/app/_hooks/studio/worker/useStreamingWorker';
+import type * as AgoraRTCType from 'agora-rtc-sdk-ng';
 
-const StreamingButtonList = () => {
+interface Props {
+  videoTrackRef:React.RefObject<AgoraRTCType.ILocalVideoTrack | null>;
+};
+
+const StreamingButtonList = ({ videoTrackRef }: Props) => {
   const uid = useUID();
-  const { streamOn, streamOff, addTrackShare, stopTrackShare, volumeControl } = useStudioManager(uid);
+  const { streamOn, streamOff, addTrackShare, stopTrackShare, volumeControl, screenTrackRef } = useStudioManager(uid);
   const { audioState, controlAudio, audioVolume } = volumeControl;
   const { data, isLoading } = useUserStreaming(uid);
   const [loadingStatus, setLoadingStatus] = useState({
@@ -36,6 +41,8 @@ const StreamingButtonList = () => {
       />
     );
   }
+
+  videoTrackRef.current = screenTrackRef.current;
 
   return (
     <div className="flex flex-col gap-2 items-center">

--- a/src/app/_components/StreamingArea/StreamingView.client.tsx
+++ b/src/app/_components/StreamingArea/StreamingView.client.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import dynamic from 'next/dynamic';
 import StreamingStatus from './StreamingStatus.client';
 import { useUserStreaming } from '@/app/_store/queries/streamingSettings/query';
 import { useUID } from '@/app/_store/context/useUid';
 import ExplainBtn from './ExplainBtn.client';
 import ChatLayout from '@/app/(route)/live/[host_uid]/widget/Chat.client';
+
+import type * as AgoraRTCType from 'agora-rtc-sdk-ng';
 
 const StreamingButtonList = dynamic(() => import('./StreamingButtonList.client'), {
   ssr: false,
@@ -23,6 +25,7 @@ const MiniVideo = dynamic(() => import('./MiniVideo.client'), {
 const StreamingView = () => {
   const uid = useUID();
   const { data } = useUserStreaming(uid);
+  const videoTrackRef = useRef<null | AgoraRTCType.ILocalVideoTrack>(null);
 
   return (
     <BeforeUnloadWrapper>
@@ -35,14 +38,14 @@ const StreamingView = () => {
 
         {/* 스트리밍 버튼 툴 */}
         <div className="mt-[30px]">
-          <StreamingButtonList />
+          <StreamingButtonList videoTrackRef={videoTrackRef}/>
         </div>
 
         {/* 현재 스트리밍 상태 */}
         <StreamingStatus />
 
         {/* 공유중인 비디오 */}
-        <MiniVideo is_active={data?.is_active || false} />
+        <MiniVideo videoTrackRef={videoTrackRef} is_active={data?.is_active || false} />
       </div>
 
       {/* 채팅 레아아웃 */}


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/minivideo/liveScreen` → `dev`

<br/>

## ✅ 작업 내용

- 기존에는 useLive를 사용하여 미니 비디오 컴포넌트에 미디어 스트림을 할당했으나, useLive는 P2P 연결 기반이므로 미디어 스트림을 구독할 때 디코딩 비용이 발생하고, 오디오 및 캔버스까지 포함되어 있기에 굉장히 무거워 리소스를 절약하고자 이를 개선할 필요가 있었습니다.

- 이를 해결하기 위해 공유하고 있는 미디어 스트림을 직접 미니 비디오 컴포넌트에 할당하려 했으나, 미디어 스트림을 `ref`에 저장했기 때문에 상태 변화를 감지할 수 없었습니다.
- 때문에 방송이 ON 상태일 때 일정 주기마다 미디어 스트림을 감지하도록 구현했습니다.
- 초기에는 미디어 스트림이 비디오 엘리먼트에 할당되면 일정 주기 감지 기능을 비활성화하도록 했지만, 이렇게 하면 공유 화면을 변경할 때 새로운 미디어 스트림을 추적할 수 없는 문제가 발생했습니다.
- 이를 해결하기 위해 특정 주기마다 미디어 스트림을 감지하는 방식으로 변경하여 문제를 해결했습니다.

<br/>

## 🌠 이미지 첨부
(여러 동작이 잘 되는 것을 확인했는데 아직 오류는 발견하지 못했읍니다)

https://github.com/user-attachments/assets/7fb07ea6-8616-49ed-a324-217df54e09cc


<br/>

## 📌 이슈 링크

- [feat/minivideo/liveScreen #190]
